### PR TITLE
feat: :sparkles: DashboardItem 추상화 방식 제시

### DIFF
--- a/app/src/components/elements/DashboardItem/index.tsx
+++ b/app/src/components/elements/DashboardItem/index.tsx
@@ -1,43 +1,63 @@
-import { Center } from '@/components/common';
+import { Center, Text, VStack } from '@/components/common';
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 
+// FIXME: title이 없는데 description이 있을 수는 없음
 type DashboardItemProps = {
-  row: number; // TODO: 더 엄밀한 Type 필요
-  col: number;
-  rowSpan: number;
-  colSpan: number;
-  children: ReactNode;
+  title?: string;
+  description?: string;
+  element: ReactNode;
 };
 
 export const DashboardItem = ({
-  children,
-  ...propsExceptChildren
+  title,
+  description,
+  element,
 }: DashboardItemProps) => {
   return (
-    <DashboardItemLayout {...propsExceptChildren}>
-      <Center w="100%" h="100%">
-        {children}
-      </Center>
+    <DashboardItemLayout>
+      <VStack w="100%" h="100%" spacing="2rem" align="start">
+        {title && (
+          <DashboardItemHeader title={title} description={description} />
+        )}
+        <Center w="100%" h="100%">
+          {element}
+        </Center>
+      </VStack>
     </DashboardItemLayout>
   );
 };
 
-type DashboardItemLayoutProps = {
-  col: number;
-  colSpan: number;
-  row: number;
-  rowSpan: number;
+const DashboardItemLayout = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 2rem;
+`;
+
+type DashboardItemHeaderProps = {
+  title?: string;
+  description?: string;
 };
 
-const DashboardItemLayout = styled.div<DashboardItemLayoutProps>`
-  background-color: ${({ theme }) => theme.colors.mono.white};
-  grid-column: ${({ col, colSpan }) => `${col} / span ${colSpan}`};
-  grid-row: ${({ row, rowSpan }) => `${row} / span ${rowSpan}`};
-  border-radius: 2rem;
-
-  transition: box-shadow 200ms ease-in-out, transform 200ms ease-in-out;
-  :hover {
-    box-shadow: 0 0.4rem 0.4rem rgba(0, 0, 0, 0.25);
-  }
-`;
+const DashboardItemHeader = ({
+  title,
+  description,
+}: DashboardItemHeaderProps) => {
+  const theme = useTheme();
+  return (
+    <VStack w="100%" align="start">
+      {title && (
+        <Text
+          fontSize={theme.fonts.size.h3}
+          fontWeight={theme.fonts.weight.medium}
+        >
+          {title}
+        </Text>
+      )}
+      {description && (
+        <Text fontSize={theme.fonts.size.caption}>{description}</Text>
+      )}
+    </VStack>
+  );
+};

--- a/app/src/components/elements/DashboardItemContainer/index.tsx
+++ b/app/src/components/elements/DashboardItemContainer/index.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+type DashboardItemContainerProps = {
+  row: number; // TODO: 더 엄밀한 Type 필요
+  col: number;
+  rowSpan: number;
+  colSpan: number;
+  element: ReactNode;
+};
+
+export const DashboardItemContainer = ({
+  element,
+  ...propsExceptElement
+}: DashboardItemContainerProps) => {
+  return (
+    <DashboardItemContainerLayout {...propsExceptElement}>
+      {element}
+    </DashboardItemContainerLayout>
+  );
+};
+
+type DashboardItemContainerLayoutProps = {
+  col: number;
+  colSpan: number;
+  row: number;
+  rowSpan: number;
+};
+
+const DashboardItemContainerLayout = styled.div<DashboardItemContainerLayoutProps>`
+  background-color: ${({ theme }) => theme.colors.mono.white};
+  grid-column: ${({ col, colSpan }) => `${col} / span ${colSpan}`};
+  grid-row: ${({ row, rowSpan }) => `${row} / span ${rowSpan}`};
+  border-radius: 2rem;
+
+  transition: box-shadow 200ms ease-in-out, transform 200ms ease-in-out;
+  :hover {
+    box-shadow: 0 0.4rem 0.4rem rgba(0, 0, 0, 0.25);
+  }
+`;

--- a/app/src/components/elements/DashboardRow/Desktop/index.tsx
+++ b/app/src/components/elements/DashboardRow/Desktop/index.tsx
@@ -1,8 +1,9 @@
+import {
+  DesktopDashboardColSize,
+  DesktopDashboardRowSize,
+} from '@/utils/types/Dashboard';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
-
-type DesktopDashboardRowSize = 1 | 2;
-type DesktopDashboardColSize = 3 | 4;
 
 type DesktopDashboardRowProps = {
   row: DesktopDashboardRowSize;
@@ -31,7 +32,7 @@ const DesktopDashboardRowLayout = styled.div<DesktopDashboardRowLayoutProps>`
   width: 100%;
   grid-template-columns: ${({ col }) => `repeat(${col}, 1fr)`};
   grid-template-rows: ${({ row, col }) =>
-    `repeat(${row}, ${col === 4 ? '13.5rem' : '18rem'})`};
+    `repeat(${row}, ${col === 4 ? '16rem' : '21rem'})`};
   column-gap: 2rem;
   row-gap: 2rem;
 `;

--- a/app/src/components/elements/DashboardRow/Mobile/index.tsx
+++ b/app/src/components/elements/DashboardRow/Mobile/index.tsx
@@ -1,8 +1,9 @@
+import {
+  MobileDashboardColSize,
+  MobileDashboardRowSize,
+} from '@/utils/types/Dashboard';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
-
-type MobileDashboardRowSize = 1 | 2;
-type MobileDashboardColSize = 1 | 2;
 
 type MobileDashboardRowProps = {
   row: MobileDashboardRowSize;

--- a/app/src/components/elements/NavBar/Mobile/index.tsx
+++ b/app/src/components/elements/NavBar/Mobile/index.tsx
@@ -25,6 +25,7 @@ const MobileNavBarLayout = styled.nav`
   position: fixed;
   bottom: 0;
   width: 100%;
+  height: 6rem;
   padding: 1.4rem 2rem;
   background-color: ${({ theme }) => theme.colors.mono.white};
 `;

--- a/app/src/components/layouts/MainLayout.tsx
+++ b/app/src/components/layouts/MainLayout.tsx
@@ -31,10 +31,10 @@ export const MainLayout = () => {
         </HStack>
       </Tablet>
       <Mobile>
-        <VStack w="100%" h="100%" spacing="2rem">
+        <VStack w="100%" spacing="2rem">
           <MobileHeader />
           <Divider />
-          <PageLayout>
+          <PageLayout css={{ marginBottom: '6rem' }}>
             <Outlet />
           </PageLayout>
         </VStack>

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import {
   DesktopDashboard,
   MobileDashboard,
 } from '@/components/elements/Dashboard';
-import { DashboardItem } from '@/components/elements/DashboardItem';
+import { DashboardItemContainer } from '@/components/elements/DashboardItemContainer';
 import { Helmet } from 'react-helmet-async';
 import {
   DesktopDashboardRow,
@@ -15,6 +15,9 @@ import {
 import { LineTestChart } from '@/components/elements/charts/LineTestChart';
 import { BarTestChart } from '@/components/elements/charts/BarTestChart';
 import { PieTestChart } from '@/components/elements/charts/PieTestChart';
+import { DashboardItem } from '@/components/elements/DashboardItem';
+import { useHomePage } from './hooks/useHomePage';
+import { dashboardContents } from './hooks/dashboardContents';
 
 const GET_USER = gql(`
   query GetUser($id: Int!) {
@@ -27,6 +30,8 @@ const GET_USER = gql(`
 
 // TODO: Mobile Page에는 Tabbar 때문에 아래 marginBottom 필요
 export const HomePage = () => {
+  const { desktopDashboard, mobileDashboard } = useHomePage();
+
   // const { loading, error, data } = useQuery(GET_USER, {
   //   variables: {
   //     id: 99947,
@@ -54,72 +59,54 @@ export const HomePage = () => {
       </Helmet>
       <AboveTablet>
         <DesktopDashboard>
-          <DesktopDashboardRow row={2} col={4}>
-            <DashboardItem row={1} col={1} rowSpan={1} colSpan={1}>
-              1/8
-            </DashboardItem>
-            <DashboardItem row={2} col={1} rowSpan={1} colSpan={1}>
-              1/8
-            </DashboardItem>
-            <DashboardItem row={1} col={2} rowSpan={2} colSpan={1}>
-              {/* <LineTestChart size={'sm'} /> */}
-            </DashboardItem>
-            <DashboardItem row={1} col={3} rowSpan={2} colSpan={1}>
-              {/* <BarTestChart size={'sm'} /> */}
-            </DashboardItem>
-            <DashboardItem row={1} col={4} rowSpan={2} colSpan={1}>
-              {/* <PieTestChart size={'sm'} /> */}
-            </DashboardItem>
-          </DesktopDashboardRow>
-          <DesktopDashboardRow row={2} col={3}>
-            <DashboardItem row={1} col={1} rowSpan={2} colSpan={1}>
-              {/* <PieTestChart size={'lg'} /> */}
-            </DashboardItem>
-            <DashboardItem row={1} col={2} rowSpan={2} colSpan={1}>
-              {/* <LineTestChart size={'lg'} /> */}
-            </DashboardItem>
-            <DashboardItem row={1} col={3} rowSpan={2} colSpan={1}>
-              {/* <BarTestChart size={'lg'} /> */}
-            </DashboardItem>
-          </DesktopDashboardRow>
+          {desktopDashboard.map(({ row, col, items }, rowIdx) => (
+            <DesktopDashboardRow key={rowIdx} row={row} col={col}>
+              {items.map(
+                ({ row, col, rowSpan, colSpan, elementId }, itemIdx) => (
+                  <DashboardItemContainer
+                    key={itemIdx}
+                    row={row}
+                    col={col}
+                    rowSpan={rowSpan}
+                    colSpan={colSpan}
+                    element={
+                      <DashboardItem
+                        title={dashboardContents[elementId].title}
+                        description={dashboardContents[elementId].description}
+                        element={<p>...</p>}
+                      />
+                    }
+                  />
+                ),
+              )}
+            </DesktopDashboardRow>
+          ))}
         </DesktopDashboard>
       </AboveTablet>
       <Mobile>
         <MobileDashboard>
-          <MobileDashboardRow row={1} col={2}>
-            <DashboardItem row={1} col={1} rowSpan={1} colSpan={1}>
-              1/4
-            </DashboardItem>
-            <DashboardItem row={1} col={2} rowSpan={1} colSpan={1}>
-              1/4
-            </DashboardItem>
-          </MobileDashboardRow>
-          <MobileDashboardRow row={2} col={2}>
-            <DashboardItem row={1} col={1} rowSpan={2} colSpan={1}>
-              2/4
-            </DashboardItem>
-            <DashboardItem row={1} col={2} rowSpan={2} colSpan={1}>
-              2/4
-            </DashboardItem>
-          </MobileDashboardRow>
-          <MobileDashboardRow row={2} col={2}>
-            <DashboardItem row={1} col={1} rowSpan={2} colSpan={1}>
-              2/4
-            </DashboardItem>
-            <DashboardItem row={1} col={2} rowSpan={2} colSpan={1}>
-              2/4
-            </DashboardItem>
-          </MobileDashboardRow>
-          <MobileDashboardRow row={2} col={2}>
-            <DashboardItem row={1} col={1} rowSpan={2} colSpan={1}>
-              2/4
-            </DashboardItem>
-          </MobileDashboardRow>
-          <MobileDashboardRow row={1} col={1}>
-            <DashboardItem row={1} col={1} rowSpan={1} colSpan={1}>
-              1/1
-            </DashboardItem>
-          </MobileDashboardRow>
+          {mobileDashboard.map(({ row, col, items }, rowIdx) => (
+            <MobileDashboardRow key={rowIdx} row={row} col={col}>
+              {items.map(
+                ({ row, col, rowSpan, colSpan, elementId }, itemIdx) => (
+                  <DashboardItemContainer
+                    key={itemIdx}
+                    row={row}
+                    col={col}
+                    rowSpan={rowSpan}
+                    colSpan={colSpan}
+                    element={
+                      <DashboardItem
+                        title={dashboardContents[elementId].title}
+                        description={dashboardContents[elementId].description}
+                        element={<p>...</p>}
+                      />
+                    }
+                  />
+                ),
+              )}
+            </MobileDashboardRow>
+          ))}
         </MobileDashboard>
       </Mobile>
     </>

--- a/app/src/pages/hooks/dashboardContents.ts
+++ b/app/src/pages/hooks/dashboardContents.ts
@@ -1,0 +1,43 @@
+import { DashboardItemInfo } from '@/utils/types/Dashboard';
+
+export const dashboardContents: DashboardItemInfo[] = [
+  {
+    id: 0,
+    title: '주간 총 평가 횟수',
+    description: '(2023.02.19 ~ 2023.02.26. / 1주)',
+  },
+  {
+    id: 1,
+    title: '이번 달 누적 블랙홀 인원',
+    description: '(2023.02.01. 시작)',
+  },
+  {
+    id: 2,
+    title: '지금 가장 많은 사람이 참여하는 과제는?',
+  },
+  {
+    id: 3,
+    title: '누적 평가 횟수 랭킹',
+    description: '(라 피신 시작일 기준)',
+  },
+  {
+    id: 4,
+    title: '레벨 랭킹',
+    description: '(전체 기수 대상)',
+  },
+  {
+    id: 5,
+    title: '월간 경험치 증가량 랭킹',
+    description: '(2023.01. / 1개월)',
+  },
+  {
+    id: 6,
+    title: '월간 출석 시간 랭킹',
+    description: '(2023.01. / 1개월)',
+  },
+  {
+    id: 7,
+    title: '직전 회차 시험 Rank 별 통과율',
+    description: '(응시 시간 : 2023.02.24.(금) 14:00)',
+  },
+];

--- a/app/src/pages/hooks/useHomePage.ts
+++ b/app/src/pages/hooks/useHomePage.ts
@@ -1,0 +1,168 @@
+import {
+  DesktopDashboardRowInfo,
+  MobileDashboardRowInfo,
+} from '@/utils/types/Dashboard';
+
+export const useHomePage = () => {
+  const desktopDashboard: DesktopDashboardRowInfo[] = [
+    {
+      row: 2,
+      col: 4,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 1,
+          colSpan: 1,
+          elementId: 0,
+        },
+        {
+          row: 2,
+          col: 1,
+          rowSpan: 1,
+          colSpan: 1,
+          elementId: 1,
+        },
+        {
+          row: 1,
+          col: 2,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 2,
+        },
+        {
+          row: 1,
+          col: 3,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 3,
+        },
+        {
+          row: 1,
+          col: 4,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 4,
+        },
+      ],
+    },
+    {
+      row: 2,
+      col: 3,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 5,
+        },
+        {
+          row: 1,
+          col: 2,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 6,
+        },
+        {
+          row: 1,
+          col: 3,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 7,
+        },
+      ],
+    },
+  ];
+
+  const mobileDashboard: MobileDashboardRowInfo[] = [
+    {
+      row: 1,
+      col: 2,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 1,
+          colSpan: 1,
+          elementId: 0,
+        },
+        {
+          row: 1,
+          col: 2,
+          rowSpan: 1,
+          colSpan: 1,
+          elementId: 1,
+        },
+      ],
+    },
+    {
+      row: 2,
+      col: 2,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 2,
+        },
+        {
+          row: 1,
+          col: 2,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 3,
+        },
+      ],
+    },
+    {
+      row: 2,
+      col: 2,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 4,
+        },
+        {
+          row: 1,
+          col: 2,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 5,
+        },
+      ],
+    },
+    {
+      row: 2,
+      col: 2,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 2,
+          colSpan: 1,
+          elementId: 6,
+        },
+      ],
+    },
+    {
+      row: 1,
+      col: 1,
+      items: [
+        {
+          row: 1,
+          col: 1,
+          rowSpan: 1,
+          colSpan: 1,
+          elementId: 7,
+        },
+      ],
+    },
+  ];
+
+  return { desktopDashboard, mobileDashboard };
+};

--- a/app/src/utils/types/Dashboard.d.ts
+++ b/app/src/utils/types/Dashboard.d.ts
@@ -1,0 +1,31 @@
+export type DashboardItemInfo = {
+  id: number;
+  title?: string;
+  description?: string;
+};
+
+export type DashboardItemContainerInfo = {
+  row: number;
+  col: number;
+  rowSpan: number;
+  colSpan: number;
+  elementId: number;
+};
+
+export type DesktopDashboardRowInfo = {
+  row: DesktopDashboardRowSize;
+  col: DesktopDashboardColSize;
+  items: DashboardItemContainerInfo[];
+};
+
+export type MobileDashboardRowInfo = {
+  row: MobileDashboardRowSize;
+  col: MobileDashboardColSize;
+  items: DashboardItemContainerInfo[];
+};
+
+export type DesktopDashboardRowSize = 1 | 2;
+export type DesktopDashboardColSize = 3 | 4;
+
+export type MobileDashboardRowSize = 1 | 2;
+export type MobileDashboardColSize = 1 | 2;


### PR DESCRIPTION
page에 많던 DashboardRow, DashboardItem들을 map을 이용하여 줄이는 방식을 생각해봤습니다. 
Chart는 아직 추가해보지 못햇지만 @lev-Zero 님과의 협업을 위해 일단 중간 과정에서 올립니다. 

커밋 보실 때 헷갈릴만한 것 하나 공유드립니다. 
기존 DashboardItem -> DashboardItemContainer로 명칭 변경, DashboardItemContainer에는 rowSpan, colSpan 등 기본 Grid 속성만 들어있음. 
DashboardItem에 제목, 세부 설명 및 Element(이후 차트가 들어갈 부분)을 인자로 받도록 되어있습니다. 
DashboardItem.tsx를 보실 때 수정된 게 아니라 새로 생긴 파일임을 염두하시고 보면 이해하실 수 있을 것 같아요