### PR TITLE
💄 [Feature] ProjectPage 디자인 변경

### DIFF
--- a/app/src/components/common/Label.tsx
+++ b/app/src/components/common/Label.tsx
@@ -31,7 +31,7 @@ export const Label = ({
 type StyledLabelProps = Omit<LabelProps, 'text' | 'color'>;
 
 const StyledLabel = styled.div<StyledLabelProps>`
-  padding: 0.2rem 1.2rem;
+  padding: 0.3rem 1.5rem;
   border-radius: 2rem;
   background-color: ${({ theme, bgColor = theme.colors.primary.default }) =>
     bgColor};

--- a/app/src/components/elements/Footer/AboveTabletFooter.tsx
+++ b/app/src/components/elements/Footer/AboveTabletFooter.tsx
@@ -1,4 +1,4 @@
-import { BoldText, HStack, Text } from '@components/common';
+import { HStack, Text } from '@components/common';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -9,19 +9,15 @@ export const AboveTabletFooter = () => {
     <FooterLayout>
       <HStack h="100%">
         <Text color={theme.colors.mono.gray300} selectable>
-          ©2023 42Stat |
-        </Text>
-        <a
-          target="_blank"
-          rel="noreferrer"
-          href="https://github.com/orgs/42Statistics/repositories"
-        >
-          <BoldText color={theme.colors.mono.gray300} selectable>
-            &nbsp;Github&nbsp;
-          </BoldText>
-        </a>
-        <Text color={theme.colors.mono.gray300} selectable>
-          | 자료에 대한 신뢰 여부는 전적으로 사용자의 책임입니다.
+          ©2023 42Stat |&nbsp;
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://github.com/orgs/42Statistics/repositories"
+          >
+            <strong>Github</strong>
+          </a>
+          &nbsp;| 자료에 대한 신뢰 여부는 전적으로 사용자의 책임입니다.
         </Text>
       </HStack>
     </FooterLayout>

--- a/app/src/components/elements/Footer/MobileFooter.tsx
+++ b/app/src/components/elements/Footer/MobileFooter.tsx
@@ -1,4 +1,4 @@
-import { BoldText, HStack, Text, VStack } from '@components/common';
+import { HStack, Text, VStack } from '@components/common';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -10,19 +10,21 @@ export const MobileFooter = () => {
       <VStack>
         <HStack h="100%">
           <Text color={theme.colors.mono.gray300} selectable>
-            ©2023 42Stat |
+            ©2023 42Stat |&nbsp;
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://github.com/orgs/42Statistics/repositories"
+            >
+              <strong>Github</strong>
+            </a>
           </Text>
-          <a
-            target="_blank"
-            rel="noreferrer"
-            href="https://github.com/orgs/42Statistics/repositories"
-          >
-            <BoldText color={theme.colors.mono.gray300}>
-              &nbsp;Github&nbsp;
-            </BoldText>
-          </a>
         </HStack>
-        <Text color={theme.colors.mono.gray300} selectable>
+        <Text
+          color={theme.colors.mono.gray300}
+          selectable
+          style={{ textAlign: 'center' }}
+        >
           자료에 대한 신뢰 여부는 전적으로 사용자의 책임입니다.
         </Text>
       </VStack>

--- a/app/src/components/elements/UserSearchBar/AboveTabletUserSearchBar.tsx
+++ b/app/src/components/elements/UserSearchBar/AboveTabletUserSearchBar.tsx
@@ -162,8 +162,8 @@ const UserSearchResult = styled.div`
   top: 6rem;
   left: 0;
   width: 30rem;
-  padding: 1.5rem 4rem;
-  border-radius: 3rem;
+  padding: 2.5rem;
+  border-radius: 2rem;
   box-shadow: 0 0.4rem 0.4rem rgba(0, 0, 0, 0.25);
   background-color: ${({ theme }) => theme.colors.mono.white};
   z-index: ${({ theme }) => theme.zIndex.searchResult};

--- a/app/src/components/elements/UserSearchBar/UserSearchModal.tsx
+++ b/app/src/components/elements/UserSearchBar/UserSearchModal.tsx
@@ -5,6 +5,8 @@ import {
   BoldText,
   Clickable,
   Divider,
+  H3BoldText,
+  H3Text,
   HStack,
   Image,
   Input,
@@ -14,7 +16,6 @@ import {
   VStack,
 } from '@components/common';
 import { useTheme } from '@emotion/react';
-import styled from '@emotion/styled';
 import { MdArrowBack } from '@react-icons/all-files/md/MdArrowBack';
 import { MdSearch } from '@react-icons/all-files/md/MdSearch';
 import { isDefined } from '@utils/isDefined';
@@ -111,8 +112,8 @@ export const UserSearchModal = ({ isOpen, toggle }: ModalType) => {
         {isPreviewDisplaying ? (
           <VStack w="100%" spacing="4rem">
             {hasUserData && (
-              <VStack w="100%" align="start" spacing="1rem">
-                <BoldText>유저</BoldText>
+              <VStack w="100%" align="start" spacing="1.4rem">
+                <H3BoldText>유저</H3BoldText>
                 <Divider />
                 {userData.findUserPreview
                   .slice(0, 5)
@@ -122,9 +123,9 @@ export const UserSearchModal = ({ isOpen, toggle }: ModalType) => {
                       key={user.id}
                       onClick={() => handleUserSubmit(user.login)}
                       element={
-                        <HStack spacing="1rem">
-                          <Avatar size="1.6rem" imgUrl={user.imgUrl} />
-                          <Text>{user.login}</Text>
+                        <HStack spacing="1.4rem">
+                          <Avatar size="2rem" imgUrl={user.imgUrl} />
+                          <H3Text>{user.login}</H3Text>
                         </HStack>
                       }
                     />
@@ -132,7 +133,7 @@ export const UserSearchModal = ({ isOpen, toggle }: ModalType) => {
               </VStack>
             )}
             {hasProjectData && (
-              <VStack w="100%" align="start" spacing="1rem">
+              <VStack w="100%" align="start" spacing="1.4rem">
                 <BoldText>프로젝트</BoldText>
                 <Divider />
                 {projectData.findProjectPreview
@@ -144,8 +145,8 @@ export const UserSearchModal = ({ isOpen, toggle }: ModalType) => {
                       onClick={() => handleProjectSubmit(project.name)}
                       element={
                         <HStack spacing="1rem">
-                          <Image src={ft_logo} width="16px" />
-                          <Text>{project.name}</Text>
+                          <Image src={ft_logo} width="20px" />
+                          <H3Text>{project.name}</H3Text>
                         </HStack>
                       }
                     />
@@ -163,10 +164,3 @@ export const UserSearchModal = ({ isOpen, toggle }: ModalType) => {
     </Modal>
   );
 };
-
-const UserSearchModalLayout = styled(Modal)`
-  width: 100%;
-  height: 100%;
-  background-color: ${({ theme }) => theme.colors.mono.white};
-  padding: 1.5rem;
-`;

--- a/app/src/pages/EvalLogSearchPage/EvalLogItem.tsx
+++ b/app/src/pages/EvalLogSearchPage/EvalLogItem.tsx
@@ -31,11 +31,11 @@ export const EvalLogItem = ({ element }: { element: EvalLog }) => {
           <PrimaryBoldText selectable>
             {header.teamPreview.name}
           </PrimaryBoldText>
-          <Text selectable>을&nbsp;</Text>
-          <BoldText selectable>
-            {dayjs(header.beginAt).format('YYYY-MM-DD HH:mm')}
-          </BoldText>
-          <Text selectable>에 평가하였습니다</Text>
+          <Text selectable>
+            을&nbsp;
+            <strong>{dayjs(header.beginAt).format('YYYY-MM-DD HH:mm')}</strong>
+            에 평가하였습니다
+          </Text>
           <Spacer />
           <HStack spacing="1rem">
             <BoldText>{header.projectPreview.name}</BoldText>

--- a/app/src/pages/ProjectPage/ProjectPage.tsx
+++ b/app/src/pages/ProjectPage/ProjectPage.tsx
@@ -4,13 +4,13 @@ import {
   AccentText,
   BoldText,
   Divider,
-  H3BoldText,
   H3Text,
   HStack,
   Loader,
   Text,
   VStack,
 } from '@components/common';
+import { Label } from '@components/common/Label';
 import { PieChart } from '@components/elements/Chart';
 import {
   ApolloBadRequest,
@@ -21,8 +21,9 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { withFooter } from '@hoc/withFooter';
 import { withHead } from '@hoc/withHead';
-import { HiUsers } from '@react-icons/all-files/hi/HiUsers';
+import { HiUsers } from '@react-icons/all-files/hi/HiUSers';
 import { numberWithUnitFormatter } from '@utils/formatters';
+import { titleCase } from '@utils/titleCase';
 import { Link, useParams } from 'react-router-dom';
 
 const GET_PROJECT_INFO = gql(/* GraphQL */ `
@@ -44,6 +45,7 @@ const GET_PROJECT_INFO = gql(/* GraphQL */ `
 `);
 
 const ProjectPage = () => {
+  const theme = useTheme();
   const { projectName } = useParams() as { projectName: string }; // FIXME: Type Assertion 제거
   const { loading, error, data } = useQuery(GET_PROJECT_INFO, {
     variables: { projectName },
@@ -55,113 +57,85 @@ const ProjectPage = () => {
 
   const {
     name,
-    skills,
     averagePassFinalmark,
     totalCloseCount,
     currRegisteredCount,
     passPercentage,
   } = data.getTotalPage.projectInfo;
 
+  const keywords = ['Unix logic'];
+  const skills = ['Algorithms & AI', 'Rigor', 'Imperative programming'];
+  const description =
+    'This project is your very first project as a student at 42. You will need to recode a few functions of the C standard library as well as some functions that you will use during your whole cursus.';
+
   return (
     <ProjectPageLayout>
-      <VStack w="100%" spacing="8rem">
-        <HStack spacing="10rem" wrap="wrap" align="end">
-          <VStack align="start" spacing="2rem">
-            <VStack align="start">
-              <Text>0서클</Text>
-              <BoldText fontSize="4rem">{name}</BoldText>
-            </VStack>
-            <VStack align="start" spacing="1rem">
-              <Text selectable>나만의 라이브러리 만들기</Text>
-              <AccentText>서브젝트 보기</AccentText>
-            </VStack>
-            <HStack spacing="2rem">
-              <HiUsers size="16px" />
-              <Text selectable>
-                {numberWithUnitFormatter(currRegisteredCount, '팀')} 진행 중
-              </Text>
-            </HStack>
-          </VStack>
-          <ProjectTable>
-            <tbody>
-              <tr>
-                <td>
-                  <Text>인원</Text>
-                </td>
-                <td>
-                  <Text>1인</Text>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <Text>기간</Text>
-                </td>
-                <td>
-                  <Text>70시간</Text>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <Text>경험치</Text>
-                </td>
-                <td>
-                  <Text>462 XP</Text>
-                </td>
-              </tr>
-            </tbody>
-          </ProjectTable>
-        </HStack>
-        <Divider />
-        <HStack spacing="10rem" wrap="wrap">
-          <VStack align="start" spacing="1rem">
-            <HStack>
-              <H3BoldText selectable>
-                지금까지 {numberWithUnitFormatter(totalCloseCount, '팀')}
-              </H3BoldText>
-              <H3Text selectable>이 제출했어요</H3Text>
-            </HStack>
-            <HStack>
-              <H3BoldText selectable>
-                평균 {numberWithUnitFormatter(averagePassFinalmark, '점')}
-              </H3BoldText>
-              <H3Text selectable>으로 통과합니다</H3Text>
-            </HStack>
-            <Link to={`/evallog?projectName=${name}`}>
-              <AccentText>지난 평가 보기</AccentText>
-            </Link>
-          </VStack>
-          <div style={{ width: '26rem', height: '26rem' }}>
-            <ProjectResultPercentageChart
-              labels={['101점 ~', '80 ~ 100점', '0 ~ 79점']}
-              series={[1280, 310, 551]}
+      <VStack w="100%" spacing="5rem">
+        <VStack spacing="0.5rem">
+          <Text>0서클</Text>
+          <BoldText fontSize="4rem" style={{ fontStyle: 'italic' }}>
+            {name.toUpperCase()}
+          </BoldText>
+        </VStack>
+        <VStack spacing="1rem">
+          <Text>Solo / 70 hrs. / 462 XP</Text>
+          <HStack spacing="1rem">
+            <HiUsers size="16px" />
+            <Text>
+              {numberWithUnitFormatter(currRegisteredCount, '팀')} 진행 중
+            </Text>
+          </HStack>
+        </VStack>
+        <HStack spacing="1rem" wrap="wrap">
+          {[...keywords, ...skills].map((text) => (
+            <Label
+              key={text}
+              text={titleCase(text)}
+              fontWeight={theme.fonts.weight.medium}
             />
-          </div>
+          ))}
         </HStack>
+        <div style={{ maxWidth: '400px' }}>
+          <Text selectable style={{ textAlign: 'center' }}>
+            {description}
+          </Text>
+        </div>
+        <AccentText>Intra 프로젝트 링크</AccentText>
+        <Divider />
+        <VStack spacing="2rem">
+          <HStack>
+            <H3Text selectable>
+              지금까지&nbsp;
+              <strong>{numberWithUnitFormatter(totalCloseCount, '팀')}</strong>
+              이 제출했어요
+            </H3Text>
+          </HStack>
+          <HStack>
+            <H3Text selectable>
+              평균&nbsp;
+              <strong>
+                {numberWithUnitFormatter(averagePassFinalmark, '점')}
+              </strong>
+              으로 통과합니다
+            </H3Text>
+          </HStack>
+        </VStack>
+        <Link to={`/evallog?projectName=${name}`}>
+          <AccentText>Past Evaluations</AccentText>
+        </Link>
+        <div style={{ width: '26rem', height: '26rem' }}>
+          <ProjectResultPercentageChart
+            labels={['Pass', 'Fail']}
+            series={[passPercentage, 100 - passPercentage]}
+          />
+        </div>
       </VStack>
     </ProjectPageLayout>
   );
 };
 
 const ProjectPageLayout = styled.div`
-  width: 100%;
-  padding: 10rem;
-  background-color: ${({ theme }) => theme.colors.mono.white};
-  border-radius: 2rem;
-`;
-
-const ProjectTable = styled.table`
-  text-align: center;
-  white-space: nowrap;
-
-  th,
-  td {
-    padding: 0.8rem 2rem;
-  }
-
-  & td:first-of-type {
-    color: ${({ theme }) => theme.colors.primary.default};
-    font-weight: ${({ theme }) => theme.fonts.weight.medium};
-  }
+  padding-top: 4rem;
 `;
 
 type ProjectResultPercentageChartProps = {
@@ -176,11 +150,7 @@ const ProjectResultPercentageChart = ({
   const theme = useTheme();
 
   const options: ApexCharts.ApexOptions = {
-    colors: [
-      theme.colors.semantic.pass,
-      theme.colors.semantic.warning,
-      theme.colors.semantic.fail,
-    ],
+    colors: [theme.colors.semantic.pass, theme.colors.semantic.fail],
     tooltip: {
       y: {
         formatter: (value) => numberWithUnitFormatter(value, '팀'),

--- a/app/src/pages/ProjectPage/ProjectPage.tsx
+++ b/app/src/pages/ProjectPage/ProjectPage.tsx
@@ -63,8 +63,12 @@ const ProjectPage = () => {
     passPercentage,
   } = data.getTotalPage.projectInfo;
 
-  const keywords = ['Unix logic'];
-  const skills = ['Algorithms & AI', 'Rigor', 'Imperative programming'];
+  const keywords = [
+    'Sorting algorithms',
+    'Battery concept and handling elements',
+    'Algorithm implementation',
+  ];
+  const skills = ['Unix', 'Rigor', 'Algorithms & AI', 'Imperative programming'];
   const description =
     'This project is your very first project as a student at 42. You will need to recode a few functions of the C standard library as well as some functions that you will use during your whole cursus.';
 
@@ -86,15 +90,27 @@ const ProjectPage = () => {
             </Text>
           </HStack>
         </VStack>
-        <HStack spacing="1rem" wrap="wrap">
-          {[...keywords, ...skills].map((text) => (
-            <Label
-              key={text}
-              text={titleCase(text)}
-              fontWeight={theme.fonts.weight.medium}
-            />
-          ))}
-        </HStack>
+        <VStack spacing="4rem">
+          <HStack spacing="1rem" wrap="wrap">
+            {keywords.map((text) => (
+              <Label
+                key={text}
+                text={titleCase(text)}
+                bgColor={theme.colors.accent.default}
+                fontWeight={theme.fonts.weight.medium}
+              />
+            ))}
+          </HStack>
+          <HStack spacing="1rem" wrap="wrap">
+            {skills.map((text) => (
+              <Label
+                key={text}
+                text={titleCase(text)}
+                fontWeight={theme.fonts.weight.medium}
+              />
+            ))}
+          </HStack>
+        </VStack>
         <div style={{ maxWidth: '400px' }}>
           <Text selectable style={{ textAlign: 'center' }}>
             {description}

--- a/app/src/styles/global.tsx
+++ b/app/src/styles/global.tsx
@@ -65,4 +65,8 @@ export const global = () => css`
     font-size: 1.4rem;
     background-color: #f9f9f9; // body가 아닌 다른 곳에 넣으면 스크롤 시 흰색이 보임
   }
+
+  strong {
+    font-weight: bold; // 글 쓸 때 필요함
+  }
 `;

--- a/app/src/styles/global.tsx
+++ b/app/src/styles/global.tsx
@@ -69,4 +69,13 @@ export const global = () => css`
   strong {
     font-weight: bold; // 글 쓸 때 필요함
   }
+
+  ::moz-selection {
+    /* moz-는 firefox에서 사용하는 속성 */
+    background: #e5f6e4;
+  }
+
+  ::selection {
+    background: #e5f6e4;
+  }
 `;


### PR DESCRIPTION
## Summary

ProjectPage 디자인을 변경해보았습니다.

<img width="1435" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/d1310f62-6d48-4fd8-b519-aa719d3e6634">
<img width="1432" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/c67c6882-682e-4f98-ab27-fcd599d510fc">

## Describe your changes

- ProjectPage 디자인 변경
  - 이전 디자인에서 추가로 필요한 데이터 : `keywords`, `skills`, `description` (백엔드와 상의 완료)
  - 이전 디자인으로부터의 변경점
    1. 차트가 평가 당 점수(101 ~ / 80 ~ 100 / 0 ~ 79점)이 아닌 팀 당 Pass / Fail 비율로 변경되었습니다. 
    2. 기존 `C`, `Makefile` 처럼 더 직관적인 라벨을 커스텀으로 달려고 했으나 모든 과제에 대하여 제작해야 하기도 하고, `keywords`와 `skills`가 제 생각보다 더 상세하게 잘 와서 그냥 사용하기로 했습니다. 
    3. 기존 `description` 대신 한글로 짧게 과제마다 적으려고 했으나 2의 이유와 동일한 이유로 `description`으로 그냥 사용하기로 했습니다.
- 자잘한 스타일링 (Label 패딩 수정)
- 자잘한 리팩토링 (global.tsx에 strong 태그 굵게 만드는 CSS Selector 추가) : 기존 방식으로는 텍스트를 드래그했을 때 끊기는 부분이 있었음. 

## Issue number and link
