### PR TITLE
✨ [Feature] 리더보드 페이지 주간/월간, 페이지 버튼, 자기일 때 색 변화

### DIFF
--- a/app/src/components/elements/PageBtnList/PageBtn.tsx
+++ b/app/src/components/elements/PageBtnList/PageBtn.tsx
@@ -1,0 +1,30 @@
+import { Clickable, H3Text } from '@components/common';
+
+type PageBtnProps = {
+  currPageNumber: number;
+  pageNumber: number;
+  setPageNumber: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export const PageBtn = ({
+  currPageNumber,
+  pageNumber,
+  setPageNumber,
+}: PageBtnProps) => {
+  const handleClick = () => {
+    if (pageNumber === currPageNumber) {
+      return;
+    }
+    setPageNumber(pageNumber);
+  };
+  return (
+    <Clickable
+      onClick={handleClick}
+      element={
+        <H3Text fontWeight={pageNumber === currPageNumber ? 700 : 400}>
+          {pageNumber}
+        </H3Text>
+      }
+    />
+  );
+};

--- a/app/src/components/elements/PageBtnList/index.tsx
+++ b/app/src/components/elements/PageBtnList/index.tsx
@@ -1,6 +1,7 @@
-import { Clickable, H3Text, HStack } from '@components/common';
+import { Clickable, H3Text, HStack, Spacer, VStack } from '@components/common';
 import { IoIosArrowBack } from '@react-icons/all-files/io/IoIosArrowBack';
 import { IoIosArrowForward } from '@react-icons/all-files/io/IoIosArrowForward';
+import { Mobile, TabletAndAbove } from '@utils/responsive/Device';
 import { PageBtn } from './PageBtn';
 
 type PageBtnListProps = {
@@ -41,37 +42,78 @@ export const PageBtnList = ({
   };
 
   return (
-    <HStack h="8rem" spacing="6rem">
-      <Clickable
-        onClick={handleClickStartBtn}
-        disabled={start === 1}
-        element={<H3Text>처음으로</H3Text>}
-      />
-      <HStack spacing="2rem">
-        <Clickable
-          onClick={handleClickBackBtn}
-          disabled={start === 1}
-          element={<IoIosArrowBack />}
-        />
-        {pageNumberList.map((pageNumber) => (
-          <PageBtn
-            key={pageNumber}
-            currPageNumber={currPageNumber}
-            pageNumber={pageNumber}
-            setPageNumber={setPageNumber}
+    <>
+      <TabletAndAbove>
+        <HStack h="8rem" spacing="6rem">
+          <Clickable
+            onClick={handleClickStartBtn}
+            disabled={currPageNumber === 1}
+            element={<H3Text>처음으로</H3Text>}
           />
-        ))}
-        <Clickable
-          onClick={handleClickForwardBtn}
-          disabled={pageNumberList.includes(totalPageNumber)}
-          element={<IoIosArrowForward />}
-        />
-      </HStack>
-      <Clickable
-        onClick={handleClickEndBtn}
-        disabled={currPageNumber === totalPageNumber}
-        element={<H3Text>끝으로</H3Text>}
-      />
-    </HStack>
+          <HStack spacing="2rem">
+            <Clickable
+              onClick={handleClickBackBtn}
+              disabled={start === 1}
+              element={<IoIosArrowBack />}
+            />
+            {pageNumberList.map((pageNumber) => (
+              <PageBtn
+                key={pageNumber}
+                currPageNumber={currPageNumber}
+                pageNumber={pageNumber}
+                setPageNumber={setPageNumber}
+              />
+            ))}
+            <Clickable
+              onClick={handleClickForwardBtn}
+              disabled={pageNumberList.includes(totalPageNumber)}
+              element={<IoIosArrowForward />}
+            />
+          </HStack>
+          <Clickable
+            onClick={handleClickEndBtn}
+            disabled={currPageNumber === totalPageNumber}
+            element={<H3Text>끝으로</H3Text>}
+          />
+        </HStack>
+      </TabletAndAbove>
+      <Mobile>
+        <VStack w="100%" h="10rem" spacing="1.4rem">
+          <HStack spacing="2rem">
+            <Clickable
+              onClick={handleClickBackBtn}
+              disabled={start === 1}
+              element={<IoIosArrowBack />}
+            />
+            {pageNumberList.map((pageNumber) => (
+              <PageBtn
+                key={pageNumber}
+                currPageNumber={currPageNumber}
+                pageNumber={pageNumber}
+                setPageNumber={setPageNumber}
+              />
+            ))}
+            <Clickable
+              onClick={handleClickForwardBtn}
+              disabled={pageNumberList.includes(totalPageNumber)}
+              element={<IoIosArrowForward />}
+            />
+          </HStack>
+          <HStack w="100%">
+            <Clickable
+              onClick={handleClickStartBtn}
+              disabled={currPageNumber === 1}
+              element={<H3Text>처음으로</H3Text>}
+            />
+            <Spacer />
+            <Clickable
+              onClick={handleClickEndBtn}
+              disabled={currPageNumber === totalPageNumber}
+              element={<H3Text>끝으로</H3Text>}
+            />
+          </HStack>
+        </VStack>
+      </Mobile>
+    </>
   );
 };

--- a/app/src/components/elements/PageBtnList/index.tsx
+++ b/app/src/components/elements/PageBtnList/index.tsx
@@ -1,0 +1,77 @@
+import { Clickable, H3Text, HStack } from '@components/common';
+import { IoIosArrowBack } from '@react-icons/all-files/io/IoIosArrowBack';
+import { IoIosArrowForward } from '@react-icons/all-files/io/IoIosArrowForward';
+import { PageBtn } from './PageBtn';
+
+type PageBtnListProps = {
+  currPageNumber: number;
+  setPageNumber: React.Dispatch<React.SetStateAction<number>>;
+  totalPageNumber: number;
+};
+
+export const PageBtnList = ({
+  currPageNumber,
+  setPageNumber,
+  totalPageNumber,
+}: PageBtnListProps) => {
+  const start = Math.floor((currPageNumber - 1) / 10) * 10 + 1;
+  const end = Math.min(start + 9, totalPageNumber);
+  const pageNumberList = Array.from(
+    { length: end - start + 1 },
+    (_, i) => start + i,
+  );
+
+  const handleClickBackBtn = () => {
+    if (currPageNumber === 1) {
+      return;
+    }
+    setPageNumber(start - 10);
+  };
+
+  const handleClickForwardBtn = () => {
+    setPageNumber(end + 1);
+  };
+
+  const handleClickStartBtn = () => {
+    setPageNumber(1);
+  };
+
+  const handleClickEndBtn = () => {
+    setPageNumber(totalPageNumber);
+  };
+
+  return (
+    <HStack h="8rem" spacing="6rem">
+      <Clickable
+        onClick={handleClickStartBtn}
+        disabled={start === 1}
+        element={<H3Text>처음으로</H3Text>}
+      />
+      <HStack spacing="2rem">
+        <Clickable
+          onClick={handleClickBackBtn}
+          disabled={start === 1}
+          element={<IoIosArrowBack />}
+        />
+        {pageNumberList.map((pageNumber) => (
+          <PageBtn
+            key={pageNumber}
+            currPageNumber={currPageNumber}
+            pageNumber={pageNumber}
+            setPageNumber={setPageNumber}
+          />
+        ))}
+        <Clickable
+          onClick={handleClickForwardBtn}
+          disabled={pageNumberList.includes(totalPageNumber)}
+          element={<IoIosArrowForward />}
+        />
+      </HStack>
+      <Clickable
+        onClick={handleClickEndBtn}
+        disabled={currPageNumber === totalPageNumber}
+        element={<H3Text>끝으로</H3Text>}
+      />
+    </HStack>
+  );
+};

--- a/app/src/components/templates/LeaderBoard/LeaderBoard.tsx
+++ b/app/src/components/templates/LeaderBoard/LeaderBoard.tsx
@@ -5,15 +5,21 @@ import { LeaderBoardItem } from './LeaderBoardItem';
 
 type LeaderBoardProps = {
   rankList: RankUserItemType[];
+  myRank: RankUserItemType | null;
   unit: string;
 };
 
-export const LeaderBoard = ({ rankList, unit }: LeaderBoardProps) => {
+export const LeaderBoard = ({ rankList, myRank, unit }: LeaderBoardProps) => {
   return (
     <VStack w="100%" h="100%">
       <LeaderBoardList>
-        {rankList.map((rankItem, idx) => (
-          <LeaderBoardItem key={idx} item={rankItem} unit={unit} />
+        {rankList.map((rankItem) => (
+          <LeaderBoardItem
+            key={rankItem.id}
+            item={rankItem}
+            unit={unit}
+            isMe={myRank !== null && rankItem.id === myRank.id}
+          />
         ))}
       </LeaderBoardList>
     </VStack>

--- a/app/src/components/templates/LeaderBoard/LeaderBoardItem.tsx
+++ b/app/src/components/templates/LeaderBoard/LeaderBoardItem.tsx
@@ -17,18 +17,29 @@ import { Link } from 'react-router-dom';
 type LeaderBoardItemProps = {
   item: RankUserItemType;
   unit: string;
+  isMe?: boolean;
 };
 
-export const LeaderBoardItem = ({ item, unit }: LeaderBoardItemProps) => {
+export const LeaderBoardItem = ({
+  item,
+  unit,
+  isMe = false,
+}: LeaderBoardItemProps) => {
   const theme = useTheme();
   const { name, imgUrl, rank, value } = item;
-  const color =
-    rank <= 3 ? theme.colors.accent.default : theme.colors.mono.black;
+
+  const getColor = (rank: number, isMe: boolean) => {
+    if (isMe) return theme.colors.mono.white;
+    if (rank <= 3) return theme.colors.accent.default;
+    return theme.colors.mono.black;
+  };
+
+  const color = getColor(rank, isMe);
 
   return (
     <>
       <TabletAndAbove>
-        <TabletAndAboveLeaderBoardItemLayout>
+        <TabletAndAboveLeaderBoardItemLayout isMe={isMe}>
           <HStack w="100%" spacing="4rem">
             <H2BoldText color={color}>{rank}</H2BoldText>
             <Avatar size="3.5rem" imgUrl={imgUrl} />
@@ -43,7 +54,7 @@ export const LeaderBoardItem = ({ item, unit }: LeaderBoardItemProps) => {
         </TabletAndAboveLeaderBoardItemLayout>
       </TabletAndAbove>
       <Mobile>
-        <MobileLeaderBoardItemLayout>
+        <MobileLeaderBoardItemLayout isMe={isMe}>
           <HStack w="100%" spacing="3rem">
             <H3BoldText color={color}>{rank}</H3BoldText>
             <Avatar size="3.5rem" imgUrl={imgUrl} />
@@ -59,14 +70,18 @@ export const LeaderBoardItem = ({ item, unit }: LeaderBoardItemProps) => {
   );
 };
 
-export const TabletAndAboveLeaderBoardItemLayout = styled.li`
+export const TabletAndAboveLeaderBoardItemLayout = styled.li<{ isMe: boolean }>`
   width: 100%;
   padding: 1rem 5rem;
   border-radius: 1rem;
+  background-color: ${({ isMe, theme }) =>
+    isMe && theme.colors.primary.default} !important; // FIXME: !important
 `;
 
-export const MobileLeaderBoardItemLayout = styled.li`
+export const MobileLeaderBoardItemLayout = styled.li<{ isMe: boolean }>`
   width: 100%;
   padding: 0.7rem 2rem;
   border-radius: 1rem;
+  background-color: ${({ isMe, theme }) =>
+    isMe && theme.colors.primary.default} !important; // FIXME: !important
 `;

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTab.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTab.tsx
@@ -2,6 +2,7 @@ import { gql } from '@/__generated__';
 import { DateTemplate } from '@/__generated__/graphql';
 import { useLazyQuery } from '@apollo/client';
 import { HStack, SegmentedControl, Spacer, VStack } from '@components/common';
+import { PageBtnList } from '@components/elements/PageBtnList';
 import { useSegmentedControl } from '@utils/useSegmentedControl';
 import { useEffect, useState } from 'react';
 import { LeaderboardCoalitionScoreTabResult } from './LeaderboardCoalitionScoreTabResult';
@@ -51,7 +52,10 @@ const GET_LEADERBOARD_COALITION_SCORE = gql(/* GraphQL */ `
 `);
 
 export const LeaderboardCoalitionScoreTab = () => {
+  const SIZE_PER_PAGE = 50;
   const [search, result] = useLazyQuery(GET_LEADERBOARD_COALITION_SCORE);
+  const [pageNumber, setPageNumber] = useState<number>(1);
+  const [totalPage, setTotalPage] = useState<number>(0);
   const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
     DateTemplate.CurrWeek,
   );
@@ -72,16 +76,6 @@ export const LeaderboardCoalitionScoreTab = () => {
   ];
   const { controlRef, segments } = useSegmentedControl(options);
 
-  useEffect(() => {
-    search({
-      variables: {
-        pageSize: 50,
-        pageNumber: 1,
-        dateTemplate,
-      },
-    });
-  }, [dateTemplate, search]);
-
   const handleSegmentedControlChange = (value: string) => {
     if (value === 'weekly') {
       setDateTemplate(DateTemplate.CurrWeek);
@@ -92,17 +86,46 @@ export const LeaderboardCoalitionScoreTab = () => {
     }
   };
 
+  useEffect(() => {
+    if (result.loading) {
+      return;
+    }
+    setTotalPage(
+      result.data?.getLeaderboardScore.byDateTemplate.data.totalRanking
+        .totalCount ?? 0,
+    );
+  }, [result]);
+
+  useEffect(() => {
+    search({
+      variables: {
+        pageSize: SIZE_PER_PAGE,
+        pageNumber,
+        dateTemplate,
+      },
+    });
+  }, [dateTemplate, pageNumber, search]);
+
+  useEffect(() => {
+    setPageNumber(1);
+  }, [dateTemplate]);
+
   return (
     <VStack w="100%" spacing="2rem">
       <HStack w="100%">
         <SegmentedControl
-          callback={console.log}
+          callback={handleSegmentedControlChange}
           controlRef={controlRef}
           segments={segments}
         />
         <Spacer />
       </HStack>
       <LeaderboardCoalitionScoreTabResult result={result} />
+      <PageBtnList
+        currPageNumber={pageNumber}
+        setPageNumber={setPageNumber}
+        totalPageNumber={Math.ceil(totalPage / SIZE_PER_PAGE)}
+      />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTabResult.tsx
@@ -29,7 +29,7 @@ export const LeaderboardCoalitionScoreTabResult = ({
   if (!data) return <ApolloNotFound />;
 
   const { me, totalRanking } = data.getLeaderboardScore.byDateTemplate.data;
-  const unit = 'XP';
+  const unit = '';
 
   const myRank: RankUserItemType | null =
     me != null

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTabResult.tsx
@@ -1,0 +1,61 @@
+import {
+  GetLeaderboardCoalitionScoreQuery,
+  GetLeaderboardCoalitionScoreQueryVariables,
+} from '@/__generated__/graphql';
+import { QueryResult } from '@apollo/client';
+import { VStack } from '@components/common';
+import {
+  ApolloBadRequest,
+  ApolloNotFound,
+} from '@components/elements/DashboardContentView';
+import { LeaderBoard } from '@components/templates/LeaderBoard';
+import { LeaderBoardItem } from '@components/templates/LeaderBoard/LeaderBoardItem';
+import { LeaderBoardTabResultSkeleton } from '@pages/PageSkeletons/LeaderBoardTabResultSkeleton';
+import { isDefined } from '@utils/isDefined';
+import { RankUserItemType } from '@utils/types/Rank';
+
+type LeaderboardCoalitionScoreTabResultProps = {
+  result: QueryResult<
+    GetLeaderboardCoalitionScoreQuery,
+    GetLeaderboardCoalitionScoreQueryVariables
+  >;
+};
+
+export const LeaderboardCoalitionScoreTabResult = ({
+  result: { data, loading, error },
+}: LeaderboardCoalitionScoreTabResultProps) => {
+  if (loading) return <LeaderBoardTabResultSkeleton />;
+  if (error) return <ApolloBadRequest msg={error.message} />;
+  if (!data) return <ApolloNotFound />;
+
+  const { me, totalRanking } = data.getLeaderboardScore.byDateTemplate.data;
+  const unit = 'XP';
+
+  const myRank: RankUserItemType | null =
+    me != null
+      ? {
+          id: me.userPreview.id,
+          name: me.userPreview.login,
+          value: me.value,
+          rank: me.rank,
+          imgUrl: me.userPreview.imgUrl,
+        }
+      : null;
+
+  const rankList: RankUserItemType[] = totalRanking.nodes
+    .filter(isDefined)
+    .map(({ userPreview, value, rank }) => ({
+      id: userPreview.id,
+      name: userPreview.login,
+      value: value,
+      rank: rank,
+      imgUrl: userPreview.imgUrl,
+    }));
+
+  return (
+    <VStack w="100%" spacing="2rem">
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
+      <LeaderBoard rankList={rankList} unit={unit} />
+    </VStack>
+  );
+};

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardCoalitionScoreTabResult.tsx
@@ -54,8 +54,8 @@ export const LeaderboardCoalitionScoreTabResult = ({
 
   return (
     <VStack w="100%" spacing="2rem">
-      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
-      <LeaderBoard rankList={rankList} unit={unit} />
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} isMe />}
+      <LeaderBoard rankList={rankList} myRank={myRank} unit={unit} />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTab.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTab.tsx
@@ -1,17 +1,10 @@
 import { gql } from '@/__generated__';
 import { DateTemplate } from '@/__generated__/graphql';
-import { useQuery } from '@apollo/client';
+import { useLazyQuery } from '@apollo/client';
 import { HStack, SegmentedControl, Spacer, VStack } from '@components/common';
-import {
-  ApolloBadRequest,
-  ApolloNotFound,
-} from '@components/elements/DashboardContentView';
-import { LeaderBoard } from '@components/templates/LeaderBoard';
-import { LeaderBoardItem } from '@components/templates/LeaderBoard/LeaderBoardItem';
-import { LeaderBoardTabSkeleton } from '@pages/PageSkeletons/LeaderBoardTabSkeleton';
-import { isDefined } from '@utils/isDefined';
-import type { RankUserItemType } from '@utils/types/Rank';
 import { useSegmentedControl } from '@utils/useSegmentedControl';
+import { useEffect, useState } from 'react';
+import { LeaderboardEvalCountTabResult } from './LeaderboardEvalCountTabResult';
 
 const GET_LEADERBOARD_EVAL_COUNT = gql(/* GraphQL */ `
   query GetLeaderboardEvalCount(
@@ -58,13 +51,11 @@ const GET_LEADERBOARD_EVAL_COUNT = gql(/* GraphQL */ `
 `);
 
 export const LeaderboardEvalCountTab = () => {
-  const { loading, error, data } = useQuery(GET_LEADERBOARD_EVAL_COUNT, {
-    variables: {
-      pageSize: 50,
-      pageNumber: 1,
-      dateTemplate: DateTemplate.CurrMonth,
-    },
-  });
+  const [search, result] = useLazyQuery(GET_LEADERBOARD_EVAL_COUNT);
+  const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
+    DateTemplate.CurrWeek,
+  );
+
   const options = [
     {
       label: '주간',
@@ -81,46 +72,37 @@ export const LeaderboardEvalCountTab = () => {
   ];
   const { controlRef, segments } = useSegmentedControl(options);
 
-  if (loading) return <LeaderBoardTabSkeleton />;
-  if (error) return <ApolloBadRequest msg={error.message} />;
-  if (!data) return <ApolloNotFound />;
+  useEffect(() => {
+    search({
+      variables: {
+        pageSize: 50,
+        pageNumber: 1,
+        dateTemplate,
+      },
+    });
+  }, [dateTemplate, search]);
 
-  const { me, totalRanking } = data.getLeaderboardEvalCount.byDateTemplate.data;
-  const unit = '회';
-
-  const myRank: RankUserItemType | null =
-    me != null
-      ? {
-          id: me.userPreview.id,
-          name: me.userPreview.login,
-          value: me.value,
-          rank: me.rank,
-          imgUrl: me.userPreview.imgUrl,
-        }
-      : null;
-
-  const rankList: RankUserItemType[] = totalRanking.nodes
-    .filter(isDefined)
-    .map(({ userPreview, value, rank }) => ({
-      id: userPreview.id,
-      name: userPreview.login,
-      value: value,
-      rank: rank,
-      imgUrl: userPreview.imgUrl,
-    }));
+  const handleSegmentedControlChange = (value: string) => {
+    if (value === 'weekly') {
+      setDateTemplate(DateTemplate.CurrWeek);
+    } else if (value === 'monthly') {
+      setDateTemplate(DateTemplate.CurrMonth);
+    } else if (value === 'total') {
+      /* FIXME: DateTemplate.Total 지원되면 수정 */
+    }
+  };
 
   return (
     <VStack w="100%" spacing="2rem">
       <HStack w="100%">
         <SegmentedControl
-          callback={console.log}
+          callback={handleSegmentedControlChange}
           controlRef={controlRef}
           segments={segments}
         />
         <Spacer />
       </HStack>
-      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
-      <LeaderBoard rankList={rankList} unit={unit} />
+      <LeaderboardEvalCountTabResult result={result} />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTab.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTab.tsx
@@ -2,6 +2,7 @@ import { gql } from '@/__generated__';
 import { DateTemplate } from '@/__generated__/graphql';
 import { useLazyQuery } from '@apollo/client';
 import { HStack, SegmentedControl, Spacer, VStack } from '@components/common';
+import { PageBtnList } from '@components/elements/PageBtnList';
 import { useSegmentedControl } from '@utils/useSegmentedControl';
 import { useEffect, useState } from 'react';
 import { LeaderboardEvalCountTabResult } from './LeaderboardEvalCountTabResult';
@@ -51,7 +52,10 @@ const GET_LEADERBOARD_EVAL_COUNT = gql(/* GraphQL */ `
 `);
 
 export const LeaderboardEvalCountTab = () => {
+  const SIZE_PER_PAGE = 50;
   const [search, result] = useLazyQuery(GET_LEADERBOARD_EVAL_COUNT);
+  const [pageNumber, setPageNumber] = useState<number>(1);
+  const [totalPage, setTotalPage] = useState<number>(0);
   const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
     DateTemplate.CurrWeek,
   );
@@ -72,16 +76,6 @@ export const LeaderboardEvalCountTab = () => {
   ];
   const { controlRef, segments } = useSegmentedControl(options);
 
-  useEffect(() => {
-    search({
-      variables: {
-        pageSize: 50,
-        pageNumber: 1,
-        dateTemplate,
-      },
-    });
-  }, [dateTemplate, search]);
-
   const handleSegmentedControlChange = (value: string) => {
     if (value === 'weekly') {
       setDateTemplate(DateTemplate.CurrWeek);
@@ -91,6 +85,26 @@ export const LeaderboardEvalCountTab = () => {
       /* FIXME: DateTemplate.Total 지원되면 수정 */
     }
   };
+
+  useEffect(() => {
+    if (result.loading) {
+      return;
+    }
+    setTotalPage(
+      result.data?.getLeaderboardEvalCount.byDateTemplate.data.totalRanking
+        .totalCount ?? 0,
+    );
+  }, [result]);
+
+  useEffect(() => {
+    search({
+      variables: {
+        pageSize: SIZE_PER_PAGE,
+        pageNumber,
+        dateTemplate,
+      },
+    });
+  }, [dateTemplate, pageNumber, search]);
 
   return (
     <VStack w="100%" spacing="2rem">
@@ -103,6 +117,11 @@ export const LeaderboardEvalCountTab = () => {
         <Spacer />
       </HStack>
       <LeaderboardEvalCountTabResult result={result} />
+      <PageBtnList
+        currPageNumber={pageNumber}
+        setPageNumber={setPageNumber}
+        totalPageNumber={Math.ceil(totalPage / SIZE_PER_PAGE)}
+      />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTabResult.tsx
@@ -54,8 +54,8 @@ export const LeaderboardEvalCountTabResult = ({
 
   return (
     <VStack w="100%" spacing="2rem">
-      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
-      <LeaderBoard rankList={rankList} unit={unit} />
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} isMe />}
+      <LeaderBoard rankList={rankList} myRank={myRank} unit={unit} />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTabResult.tsx
@@ -1,0 +1,61 @@
+import {
+  GetLeaderboardEvalCountQuery,
+  GetLeaderboardEvalCountQueryVariables,
+} from '@/__generated__/graphql';
+import { QueryResult } from '@apollo/client';
+import { VStack } from '@components/common';
+import {
+  ApolloBadRequest,
+  ApolloNotFound,
+} from '@components/elements/DashboardContentView';
+import { LeaderBoard } from '@components/templates/LeaderBoard';
+import { LeaderBoardItem } from '@components/templates/LeaderBoard/LeaderBoardItem';
+import { LeaderBoardTabResultSkeleton } from '@pages/PageSkeletons/LeaderBoardTabResultSkeleton';
+import { isDefined } from '@utils/isDefined';
+import { RankUserItemType } from '@utils/types/Rank';
+
+type LeaderboardEvalCountTabResultProps = {
+  result: QueryResult<
+    GetLeaderboardEvalCountQuery,
+    GetLeaderboardEvalCountQueryVariables
+  >;
+};
+
+export const LeaderboardEvalCountTabResult = ({
+  result: { data, loading, error },
+}: LeaderboardEvalCountTabResultProps) => {
+  if (loading) return <LeaderBoardTabResultSkeleton />;
+  if (error) return <ApolloBadRequest msg={error.message} />;
+  if (!data) return <ApolloNotFound />;
+
+  const { me, totalRanking } = data.getLeaderboardEvalCount.byDateTemplate.data;
+  const unit = 'XP';
+
+  const myRank: RankUserItemType | null =
+    me != null
+      ? {
+          id: me.userPreview.id,
+          name: me.userPreview.login,
+          value: me.value,
+          rank: me.rank,
+          imgUrl: me.userPreview.imgUrl,
+        }
+      : null;
+
+  const rankList: RankUserItemType[] = totalRanking.nodes
+    .filter(isDefined)
+    .map(({ userPreview, value, rank }) => ({
+      id: userPreview.id,
+      name: userPreview.login,
+      value: value,
+      rank: rank,
+      imgUrl: userPreview.imgUrl,
+    }));
+
+  return (
+    <VStack w="100%" spacing="2rem">
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
+      <LeaderBoard rankList={rankList} unit={unit} />
+    </VStack>
+  );
+};

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardEvalCountTabResult.tsx
@@ -29,7 +29,7 @@ export const LeaderboardEvalCountTabResult = ({
   if (!data) return <ApolloNotFound />;
 
   const { me, totalRanking } = data.getLeaderboardEvalCount.byDateTemplate.data;
-  const unit = 'XP';
+  const unit = '회';
 
   const myRank: RankUserItemType | null =
     me != null

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardExpIncrementTab.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardExpIncrementTab.tsx
@@ -1,17 +1,10 @@
 import { gql } from '@/__generated__';
 import { DateTemplate } from '@/__generated__/graphql';
-import { useQuery } from '@apollo/client';
+import { useLazyQuery } from '@apollo/client';
 import { HStack, SegmentedControl, Spacer, VStack } from '@components/common';
-import {
-  ApolloBadRequest,
-  ApolloNotFound,
-} from '@components/elements/DashboardContentView';
-import { LeaderBoard } from '@components/templates/LeaderBoard';
-import { LeaderBoardItem } from '@components/templates/LeaderBoard/LeaderBoardItem';
-import { LeaderBoardTabSkeleton } from '@pages/PageSkeletons/LeaderBoardTabSkeleton';
-import { isDefined } from '@utils/isDefined';
-import type { RankUserItemType } from '@utils/types/Rank';
 import { useSegmentedControl } from '@utils/useSegmentedControl';
+import { useEffect, useState } from 'react';
+import { LeaderboardExpIncrementTabResult } from './LeaderboardExpIncrementTabResult';
 
 const GET_LEADERBOARD_EXP_INCREMENT = gql(/* GraphQL */ `
   query GetLeaderboardExpIncrement(
@@ -58,13 +51,11 @@ const GET_LEADERBOARD_EXP_INCREMENT = gql(/* GraphQL */ `
 `);
 
 export const LeaderboardExpIncrementTab = () => {
-  const { loading, error, data } = useQuery(GET_LEADERBOARD_EXP_INCREMENT, {
-    variables: {
-      pageSize: 50,
-      pageNumber: 1,
-      dateTemplate: DateTemplate.CurrMonth,
-    },
-  });
+  const [search, result] = useLazyQuery(GET_LEADERBOARD_EXP_INCREMENT);
+  const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
+    DateTemplate.CurrWeek,
+  );
+
   const options = [
     {
       label: '주간',
@@ -75,49 +66,38 @@ export const LeaderboardExpIncrementTab = () => {
       value: 'monthly',
     },
   ];
+
   const { controlRef, segments } = useSegmentedControl(options);
 
-  if (loading) return <LeaderBoardTabSkeleton />;
-  if (error) return <ApolloBadRequest msg={error.message} />;
-  if (!data) return <ApolloNotFound />;
+  useEffect(() => {
+    search({
+      variables: {
+        pageSize: 50,
+        pageNumber: 1,
+        dateTemplate,
+      },
+    });
+  }, [dateTemplate, search]);
 
-  const { me, totalRanking } =
-    data.getLeaderboardExpIncrement.byDateTemplate.data;
-  const unit = 'XP';
-
-  const myRank: RankUserItemType | null =
-    me != null
-      ? {
-          id: me.userPreview.id,
-          name: me.userPreview.login,
-          value: me.value,
-          rank: me.rank,
-          imgUrl: me.userPreview.imgUrl,
-        }
-      : null;
-
-  const rankList: RankUserItemType[] = totalRanking.nodes
-    .filter(isDefined)
-    .map(({ userPreview, value, rank }) => ({
-      id: userPreview.id,
-      name: userPreview.login,
-      value: value,
-      rank: rank,
-      imgUrl: userPreview.imgUrl,
-    }));
+  const handleSegmentedControlChange = (value: string) => {
+    if (value === 'weekly') {
+      setDateTemplate(DateTemplate.CurrWeek);
+    } else if (value === 'monthly') {
+      setDateTemplate(DateTemplate.CurrMonth);
+    }
+  };
 
   return (
     <VStack w="100%" spacing="2rem">
       <HStack w="100%">
         <SegmentedControl
-          callback={console.log}
+          callback={handleSegmentedControlChange}
           controlRef={controlRef}
           segments={segments}
         />
         <Spacer />
       </HStack>
-      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
-      <LeaderBoard rankList={rankList} unit={unit} />
+      <LeaderboardExpIncrementTabResult result={result} />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardExpIncrementTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardExpIncrementTabResult.tsx
@@ -55,8 +55,8 @@ export const LeaderboardExpIncrementTabResult = ({
 
   return (
     <VStack w="100%" spacing="2rem">
-      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
-      <LeaderBoard rankList={rankList} unit={unit} />
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} isMe />}
+      <LeaderBoard rankList={rankList} myRank={myRank} unit={unit} />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardExpIncrementTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardExpIncrementTabResult.tsx
@@ -1,0 +1,62 @@
+import {
+  GetLeaderboardExpIncrementQuery,
+  GetLeaderboardExpIncrementQueryVariables,
+} from '@/__generated__/graphql';
+import { QueryResult } from '@apollo/client';
+import { VStack } from '@components/common';
+import {
+  ApolloBadRequest,
+  ApolloNotFound,
+} from '@components/elements/DashboardContentView';
+import { LeaderBoard } from '@components/templates/LeaderBoard';
+import { LeaderBoardItem } from '@components/templates/LeaderBoard/LeaderBoardItem';
+import { LeaderBoardTabResultSkeleton } from '@pages/PageSkeletons/LeaderBoardTabResultSkeleton';
+import { isDefined } from '@utils/isDefined';
+import { RankUserItemType } from '@utils/types/Rank';
+
+type LeaderboardExpIncrementTabResultProps = {
+  result: QueryResult<
+    GetLeaderboardExpIncrementQuery,
+    GetLeaderboardExpIncrementQueryVariables
+  >;
+};
+
+export const LeaderboardExpIncrementTabResult = ({
+  result: { data, loading, error },
+}: LeaderboardExpIncrementTabResultProps) => {
+  if (loading) return <LeaderBoardTabResultSkeleton />;
+  if (error) return <ApolloBadRequest msg={error.message} />;
+  if (!data) return <ApolloNotFound />;
+
+  const { me, totalRanking } =
+    data.getLeaderboardExpIncrement.byDateTemplate.data;
+  const unit = 'XP';
+
+  const myRank: RankUserItemType | null =
+    me != null
+      ? {
+          id: me.userPreview.id,
+          name: me.userPreview.login,
+          value: me.value,
+          rank: me.rank,
+          imgUrl: me.userPreview.imgUrl,
+        }
+      : null;
+
+  const rankList: RankUserItemType[] = totalRanking.nodes
+    .filter(isDefined)
+    .map(({ userPreview, value, rank }) => ({
+      id: userPreview.id,
+      name: userPreview.login,
+      value: value,
+      rank: rank,
+      imgUrl: userPreview.imgUrl,
+    }));
+
+  return (
+    <VStack w="100%" spacing="2rem">
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
+      <LeaderBoard rankList={rankList} unit={unit} />
+    </VStack>
+  );
+};

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTab.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTab.tsx
@@ -1,8 +1,9 @@
 import { gql } from '@/__generated__';
 import { useLazyQuery } from '@apollo/client';
 import { HStack, SegmentedControl, Spacer, VStack } from '@components/common';
+import { PageBtnList } from '@components/elements/PageBtnList';
 import { useSegmentedControl } from '@utils/useSegmentedControl';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { LeaderboardLevelTabResult } from './LeaderboardLevelTabResult';
 
 const GET_LEADERBOARD_LEVEL = gql(/* GraphQL */ `
@@ -38,7 +39,10 @@ const GET_LEADERBOARD_LEVEL = gql(/* GraphQL */ `
 `);
 
 export const LeaderboardLevelTab = () => {
+  const SIZE_PER_PAGE = 50;
   const [search, result] = useLazyQuery(GET_LEADERBOARD_LEVEL);
+  const [pageNumber, setPageNumber] = useState<number>(1);
+  const [totalPage, setTotalPage] = useState<number>(0);
 
   const options = [
     {
@@ -49,13 +53,23 @@ export const LeaderboardLevelTab = () => {
   const { controlRef, segments } = useSegmentedControl(options);
 
   useEffect(() => {
+    if (result.loading) {
+      return;
+    }
+    setTotalPage(
+      result.data?.getLeaderboardLevel.total.totalRanking.totalCount ?? 0,
+    );
+  }, [result]);
+
+  useEffect(() => {
     search({
       variables: {
-        pageSize: 50,
-        pageNumber: 1,
+        pageSize: SIZE_PER_PAGE,
+        pageNumber,
       },
     });
-  }, [search]);
+    setPageNumber(pageNumber);
+  }, [search, pageNumber]);
 
   return (
     <VStack w="100%" spacing="2rem">
@@ -70,6 +84,11 @@ export const LeaderboardLevelTab = () => {
         <Spacer />
       </HStack>
       <LeaderboardLevelTabResult result={result} />
+      <PageBtnList
+        currPageNumber={pageNumber}
+        setPageNumber={setPageNumber}
+        totalPageNumber={Math.ceil(totalPage / SIZE_PER_PAGE)}
+      />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTabResult.tsx
@@ -54,8 +54,8 @@ export const LeaderboardLevelTabResult = ({
 
   return (
     <VStack w="100%" spacing="2rem">
-      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
-      <LeaderBoard rankList={rankList} unit={unit} />
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} isMe />}
+      <LeaderBoard rankList={rankList} myRank={myRank} unit={unit} />
     </VStack>
   );
 };

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTabResult.tsx
@@ -1,0 +1,61 @@
+import {
+  GetLeaderboardLevelQuery,
+  GetLeaderboardLevelQueryVariables,
+} from '@/__generated__/graphql';
+import { QueryResult } from '@apollo/client';
+import { VStack } from '@components/common';
+import {
+  ApolloBadRequest,
+  ApolloNotFound,
+} from '@components/elements/DashboardContentView';
+import { LeaderBoard } from '@components/templates/LeaderBoard';
+import { LeaderBoardItem } from '@components/templates/LeaderBoard/LeaderBoardItem';
+import { LeaderBoardTabResultSkeleton } from '@pages/PageSkeletons/LeaderBoardTabResultSkeleton';
+import { isDefined } from '@utils/isDefined';
+import { RankUserItemType } from '@utils/types/Rank';
+
+type LeaderboardLevelTabResultProps = {
+  result: QueryResult<
+    GetLeaderboardLevelQuery,
+    GetLeaderboardLevelQueryVariables
+  >;
+};
+
+export const LeaderboardLevelTabResult = ({
+  result: { data, loading, error },
+}: LeaderboardLevelTabResultProps) => {
+  if (loading) return <LeaderBoardTabResultSkeleton />;
+  if (error) return <ApolloBadRequest msg={error.message} />;
+  if (!data) return <ApolloNotFound />;
+
+  const { me, totalRanking } = data.getLeaderboardLevel.total;
+  const unit = 'XP';
+
+  const myRank: RankUserItemType | null =
+    me != null
+      ? {
+          id: me.userPreview.id,
+          name: me.userPreview.login,
+          value: me.value,
+          rank: me.rank,
+          imgUrl: me.userPreview.imgUrl,
+        }
+      : null;
+
+  const rankList: RankUserItemType[] = totalRanking.nodes
+    .filter(isDefined)
+    .map(({ userPreview, value, rank }) => ({
+      id: userPreview.id,
+      name: userPreview.login,
+      value: value,
+      rank: rank,
+      imgUrl: userPreview.imgUrl,
+    }));
+
+  return (
+    <VStack w="100%" spacing="2rem">
+      {myRank && <LeaderBoardItem item={myRank} unit={unit} />}
+      <LeaderBoard rankList={rankList} unit={unit} />
+    </VStack>
+  );
+};

--- a/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTabResult.tsx
+++ b/app/src/pages/LeaderBoardPage/tabs/LeaderboardLevelTabResult.tsx
@@ -29,7 +29,7 @@ export const LeaderboardLevelTabResult = ({
   if (!data) return <ApolloNotFound />;
 
   const { me, totalRanking } = data.getLeaderboardLevel.total;
-  const unit = 'XP';
+  const unit = '';
 
   const myRank: RankUserItemType | null =
     me != null

--- a/app/src/pages/PageSkeletons/LeaderBoardTabResultSkeleton.tsx
+++ b/app/src/pages/PageSkeletons/LeaderBoardTabResultSkeleton.tsx
@@ -1,10 +1,9 @@
 import { Skeleton, VStack } from '@components/common';
-import styled from '@emotion/styled';
 
-export const LeaderBoardTabSkeleton = () => {
+export const LeaderBoardTabResultSkeleton = () => {
   return (
     <VStack w="100%" spacing="2.5rem" align="start">
-      <SegmentedControlSkeleton />
+      {/* <SegmentedControlSkeleton /> */}
       <Skeleton style={{ height: '65px' }} />
       <VStack w="100%" spacing="1rem">
         {Array.from({ length: 50 }, (x) => x).map((_, idx) => (
@@ -15,8 +14,8 @@ export const LeaderBoardTabSkeleton = () => {
   );
 };
 
-const SegmentedControlSkeleton = styled(Skeleton)`
-  width: 100px;
-  height: 40px;
-  border-radius: 2rem;
-`;
+// const SegmentedControlSkeleton = styled(Skeleton)`
+//   width: 100px;
+//   height: 40px;
+//   border-radius: 2rem;
+// `;

--- a/app/src/providers/ApolloProvider.tsx
+++ b/app/src/providers/ApolloProvider.tsx
@@ -36,7 +36,7 @@ const client = new ApolloClient({
           getProjectInfo: {
             merge: true,
           },
-          getLeaderboardEval: {
+          getLeaderboardLevel: {
             merge: true,
           },
           getLeaderboardExpIncrement: {

--- a/app/src/providers/ApolloProvider.tsx
+++ b/app/src/providers/ApolloProvider.tsx
@@ -1,25 +1,5 @@
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 
-// const client = new ApolloClient({
-//   uri: import.meta.env.VITE_BACKEND_GRAPHQL_ENDPOINT,
-//   cache: new InMemoryCache({
-//     typePolicies: {
-//       Home: {
-//         merge: true,
-//       },
-//       Total: {
-//         merge: true,
-//       },
-//       PersonalGeneral: {
-//         merge: true,
-//       },
-//       PersonalEval: {
-//         merge: true,
-//       },
-//     },
-//   }),
-// });
-
 /**
  * @description
  * 쿼리 바뀌었을때 이부분 안건드리면 기존에 있던캐시정보에 바뀐 쿼리정보 병합하려고해서 에러발생
@@ -51,6 +31,24 @@ const client = new ApolloClient({
             merge: true,
           },
           getPersonalEvalPage: {
+            merge: true,
+          },
+          getProjectInfo: {
+            merge: true,
+          },
+          getLeaderboardEval: {
+            merge: true,
+          },
+          getLeaderboardExpIncrement: {
+            merge: true,
+          },
+          getLeaderboardEvalCount: {
+            merge: true,
+          },
+          getLeaderboardScore: {
+            merge: true,
+          },
+          getEvalLogs: {
             merge: true,
           },
         },


### PR DESCRIPTION
## Summary
- 리더보드 누적, 코알리숑 스코어 BE 오류 빼고 제작 완료

## Describe your changes
<img width="1135" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/f0535201-7862-43b6-9364-22be77bfe577">
<img width="1147" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/ffce1571-15f9-4720-9879-a9be23997912">

- Leaderboard 주간 / 월간 연동
- 자기인 경우 색 다르게
- 페이지 누르면 이동하게
<img width="581" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/d954d5ab-3f91-43b8-bb54-a733e02d9837">
<img width="545" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/9f215429-8572-43ea-9b9e-c95f1f13f8a5">


## Issue number and link
- close #68 