### PR TITLE
💄 [Design] Box-Shadow 추가하여 Theme 수정

### DIFF
--- a/app/src/@core/components/NavBar/Desktop/index.tsx
+++ b/app/src/@core/components/NavBar/Desktop/index.tsx
@@ -49,7 +49,7 @@ const Layout = styled.nav<LayoutProps>`
   height: 100%;
   padding: 3rem;
   background-color: ${({ theme }) => theme.colors.mono.white};
-  border-right: 1px solid ${({ theme }) => theme.colors.mono.gray50};
+
   border-top-right-radius: ${({ theme, fixed }) => !fixed && theme.radius.sm};
   border-bottom-right-radius: ${({ theme, fixed }) =>
     !fixed && theme.radius.sm};

--- a/app/src/@core/components/NavBar/Mobile(TabBar)/index.tsx
+++ b/app/src/@core/components/NavBar/Mobile(TabBar)/index.tsx
@@ -26,6 +26,5 @@ const Layout = styled.nav`
   height: 6rem;
   padding: 1.4rem 2rem 6rem 2rem;
   background-color: ${({ theme }) => theme.colors.mono.white};
-  border-top: 1px solid ${({ theme }) => theme.colors.mono.gray50};
   user-select: none;
 `;

--- a/app/src/@core/components/NavBar/Tablet/index.tsx
+++ b/app/src/@core/components/NavBar/Tablet/index.tsx
@@ -40,6 +40,5 @@ const Layout = styled.div`
   height: 100%;
   padding: 3rem 0;
   background-color: ${({ theme }) => theme.colors.mono.white};
-  border-right: 1px solid ${({ theme }) => theme.colors.mono.gray50};
   user-select: none;
 `;

--- a/app/src/@core/components/Spotlight/SpotlightSearchBar.tsx
+++ b/app/src/@core/components/Spotlight/SpotlightSearchBar.tsx
@@ -59,7 +59,6 @@ const Layout = styled.div<LayoutProps>`
   background-color: ${({ theme }) => theme.colors.mono.white};
   padding: 1rem 3rem;
   border-radius: ${({ theme }) => theme.radius.sm};
-  border: 2px solid ${({ theme }) => theme.colors.mono.gray50};
   outline-offset: -5px;
 
   outline: ${({ theme, isFocused }) =>

--- a/app/src/@core/layouts/MainLayout/Mobile/index.tsx
+++ b/app/src/@core/layouts/MainLayout/Mobile/index.tsx
@@ -19,7 +19,7 @@ const Layout = styled.main`
   width: 100%;
   max-width: 480px;
   min-height: 100vh;
-  padding: 1rem;
+  padding: 0 2rem;
   padding-bottom: calc(2rem + 6rem);
   margin: auto;
 `;

--- a/app/src/@core/layouts/MainLayout/mainLayoutGlobalStyle.tsx
+++ b/app/src/@core/layouts/MainLayout/mainLayoutGlobalStyle.tsx
@@ -2,6 +2,6 @@ import { css } from '@emotion/react';
 
 export const mainLayoutGlobalStyle = () => css`
   body {
-    background-color: #f4f4f4;
+    background-color: #ffffff;
   }
 `;

--- a/app/src/@core/styles/Theme.d.ts
+++ b/app/src/@core/styles/Theme.d.ts
@@ -36,6 +36,7 @@ type Colors = {
 
 type Fonts = {
   size: {
+    title: string;
     h1: string;
     h2: string;
     h3: string;

--- a/app/src/@core/styles/defaultTheme.tsx
+++ b/app/src/@core/styles/defaultTheme.tsx
@@ -24,7 +24,7 @@ const colors = {
   },
   mono: {
     black: '#161616',
-    white: '#f9f9f9',
+    white: '#ffffff',
     gray300: '#777777',
     gray200: '#999999',
     gray100: '#bbbbbb',
@@ -34,11 +34,12 @@ const colors = {
 
 const fonts = {
   size: {
-    h1: '2.8rem',
+    title: '3.2rem',
+    h1: '2.4rem',
     h2: '2.0rem',
-    h3: '1.6rem',
+    h3: '1.8rem',
     body: '1.4rem',
-    caption: '1.1rem',
+    caption: '1.2rem',
   },
   weight: {
     thin: 100,

--- a/app/src/@shared/components/Chart/BarChart.tsx
+++ b/app/src/@shared/components/Chart/BarChart.tsx
@@ -35,7 +35,7 @@ export const BarChart = ({
     },
     fill: {
       type: 'solid',
-      opacity: 0.6,
+      opacity: 1,
     },
   };
 

--- a/app/src/@shared/components/Chart/DonutChart.tsx
+++ b/app/src/@shared/components/Chart/DonutChart.tsx
@@ -30,9 +30,10 @@ export const DonutChart = ({
     },
     fill: {
       type: 'solid',
+      opacity: 1,
     },
     stroke: {
-      show: false,
+      width: 1.5,
     },
     colors: [theme.colors.primary.default],
     responsive: [],

--- a/app/src/@shared/components/Chart/HorizontalBarChart.tsx
+++ b/app/src/@shared/components/Chart/HorizontalBarChart.tsx
@@ -36,7 +36,7 @@ export const HorizontalBarChart = ({
     },
     fill: {
       type: 'solid',
-      opacity: 0.6,
+      opacity: 1,
     },
   };
 

--- a/app/src/@shared/components/Dashboard/Desktop/DesktopDashboardRow.tsx
+++ b/app/src/@shared/components/Dashboard/Desktop/DesktopDashboardRow.tsx
@@ -12,8 +12,8 @@ export const DesktopDashboardRow = styled.div<DesktopDashboardRowProps>`
   grid-template-columns: ${({ col }) => `repeat(${col}, 1fr)`};
   grid-template-rows: ${({ row, col }) =>
     `repeat(${row}, ${getHeightByCol(col)})`};
-  column-gap: 2.4rem;
-  row-gap: 2.4rem;
+  column-gap: 1rem;
+  row-gap: 1rem;
   width: 100%;
 `;
 
@@ -22,8 +22,7 @@ const getHeightByCol = (col: DesktopDashboardColSize) => {
     case 4:
       return '14rem';
     case 3:
-      return '18rem';
     default:
-      throw new Error('Invalid col size');
+      return '20rem';
   }
 };

--- a/app/src/@shared/components/Dashboard/Desktop/index.tsx
+++ b/app/src/@shared/components/Dashboard/Desktop/index.tsx
@@ -27,6 +27,6 @@ export const DesktopDashboard = ({ rows, contents }: DesktopDashboardProps) => {
 export const DesktopDashboardLayout = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 2.4rem;
+  gap: 1rem;
   width: 100%;
 `;

--- a/app/src/@shared/components/Dashboard/Mobile/MobileDashboardRow.tsx
+++ b/app/src/@shared/components/Dashboard/Mobile/MobileDashboardRow.tsx
@@ -12,16 +12,15 @@ export const MobileDashboardRow = styled.div<MobileDashboardRowProps>`
   grid-template-columns: ${({ col }) => `repeat(${col}, 1fr)`};
   grid-template-rows: ${({ row, col }) =>
     `repeat(${row}, ${getHeightByCol(col)})`};
-  column-gap: 2rem;
-  row-gap: 2rem;
+  column-gap: 1rem;
+  row-gap: 1rem;
   width: 100%;
 `;
 
 const getHeightByCol = (col: MobileDashboardColSize) => {
   switch (col) {
     case 1:
-      return '15rem';
     default:
-      throw new Error('Invalid col size');
+      return '18rem';
   }
 };

--- a/app/src/@shared/components/Dashboard/Mobile/index.tsx
+++ b/app/src/@shared/components/Dashboard/Mobile/index.tsx
@@ -27,6 +27,6 @@ export const MobileDashboard = ({ rows, contents }: MobileDashboardProps) => {
 export const MobileDashboardLayout = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
   width: 100%;
 `;

--- a/app/src/@shared/components/Dashboard/Tablet/TabletDashboardRow.tsx
+++ b/app/src/@shared/components/Dashboard/Tablet/TabletDashboardRow.tsx
@@ -12,18 +12,17 @@ export const TabletDashboardRow = styled.div<TabletDashboardRowProps>`
   grid-template-columns: ${({ col }) => `repeat(${col}, 1fr)`};
   grid-template-rows: ${({ row, col }) =>
     `repeat(${row}, ${getHeightByCol(col)})`};
-  column-gap: 2.4rem;
-  row-gap: 2.4rem;
+  column-gap: 1rem;
+  row-gap: 1rem;
   width: 100%;
 `;
 
 const getHeightByCol = (col: TabletDashboardColSize) => {
   switch (col) {
     case 3:
-      return '14rem';
+      return '16rem';
     case 2:
-      return '18rem';
     default:
-      throw new Error('Invalid col size');
+      return '20rem';
   }
 };

--- a/app/src/@shared/components/Dashboard/Tablet/index.tsx
+++ b/app/src/@shared/components/Dashboard/Tablet/index.tsx
@@ -27,6 +27,6 @@ export const TabletDashboard = ({ rows, contents }: TabletDashboardProps) => {
 export const TabletDashboardLayout = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 2.4rem;
+  gap: 1rem;
   width: 100%;
 `;

--- a/app/src/@shared/components/Dashboard/shared/DashboardItem.tsx
+++ b/app/src/@shared/components/Dashboard/shared/DashboardItem.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { CustomBox } from '@shared/ui-kit-styled';
 
-type DashboardItemProps = {
+export type DashboardItemProps = {
   row: number; // TODO: 더 엄밀한 Type 필요
   col: number;
   rowSpan: number;

--- a/app/src/@shared/components/DashboardContent.tsx
+++ b/app/src/@shared/components/DashboardContent.tsx
@@ -1,5 +1,6 @@
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { CaptionText, Center, H3BoldText, VStack } from '@shared/ui-kit';
+import { CaptionText, Center, H3MediumText, VStack } from '@shared/ui-kit';
 
 export type DashboardContentProps = React.PropsWithChildren<{
   title?: string;
@@ -13,12 +14,18 @@ export const DashboardContent = ({
   children,
   isApexChart = false,
 }: DashboardContentProps) => {
+  const theme = useTheme();
+
   return (
     <Layout>
       <VStack w="100%" h="100%" spacing="2rem" align="start">
-        <VStack w="100%" align="start">
-          {title ? <H3BoldText>{title}</H3BoldText> : null}
-          {description ? <CaptionText>{description}</CaptionText> : null}
+        <VStack w="100%" align="start" style={{ marginLeft: '1rem' }}>
+          {title ? <H3MediumText>{title}</H3MediumText> : null}
+          {description ? (
+            <CaptionText color={theme.colors.mono.gray300}>
+              {description}
+            </CaptionText>
+          ) : null}
         </VStack>
         {!isApexChart ? (
           <Center>{children}</Center>
@@ -33,5 +40,5 @@ export const DashboardContent = ({
 const Layout = styled.div`
   width: 100%;
   height: 100%;
-  padding: 2rem;
+  padding: 2.4rem;
 `;

--- a/app/src/@shared/components/DashboardContentView/NumberCompare/Diff.tsx
+++ b/app/src/@shared/components/DashboardContentView/NumberCompare/Diff.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@emotion/react';
 import { ReactComponent as TriangleDown } from '@shared/assets/icon/triangle-down.svg';
 import { ReactComponent as TriangleUp } from '@shared/assets/icon/triangle-up.svg';
-import { HStack, Text } from '@shared/ui-kit';
+import { H3Text, HStack } from '@shared/ui-kit';
 
 type DiffProps = {
   curr: number;
@@ -16,8 +16,8 @@ export const Diff = ({ curr, last }: DiffProps) => {
 
   return (
     <HStack align="baseline" spacing="0.5rem">
-      <ArrowSvg width={10} height={10} fill={color} />
-      <Text color={color}>{Math.abs(diff).toLocaleString()}</Text>
+      <ArrowSvg width={12} height={12} fill={color} />
+      <H3Text color={color}>{Math.abs(diff).toLocaleString()}</H3Text>
     </HStack>
   );
 };

--- a/app/src/@shared/components/DashboardContentView/NumberCompare/index.tsx
+++ b/app/src/@shared/components/DashboardContentView/NumberCompare/index.tsx
@@ -1,4 +1,4 @@
-import { H1BoldText, HStack, Text } from '@shared/ui-kit';
+import { H1MediumText, H3Text, HStack } from '@shared/ui-kit';
 import { NoneDash } from '../Error/NoneDash';
 import { Diff } from './Diff';
 
@@ -12,8 +12,8 @@ export const NumberCompare = ({ curr, last, unit }: NumberCompareProps) => {
   return (
     <HStack spacing="2rem" align="baseline">
       <HStack align="baseline" spacing="0.15rem">
-        <H1BoldText>{curr.toLocaleString()}</H1BoldText>
-        <Text>{unit}</Text>
+        <H1MediumText>{curr.toLocaleString()}</H1MediumText>
+        <H3Text>{unit}</H3Text>
       </HStack>
       {curr !== last ? <Diff curr={curr} last={last} /> : <NoneDash />}
     </HStack>

--- a/app/src/@shared/components/DashboardContentView/NumberDefault/index.tsx
+++ b/app/src/@shared/components/DashboardContentView/NumberDefault/index.tsx
@@ -1,4 +1,4 @@
-import { H1BoldText, HStack, Text } from '@shared/ui-kit';
+import { H1MediumText, H3Text, HStack } from '@shared/ui-kit';
 
 type NumberDefaultProps = {
   number: number;
@@ -13,12 +13,12 @@ export const NumberDefault = ({
 }: NumberDefaultProps) => {
   return (
     <HStack align="baseline" spacing="0.15rem">
-      <H1BoldText>
+      <H1MediumText>
         {fixedNumber === undefined
           ? number.toLocaleString()
           : number.toFixed(2)}
-      </H1BoldText>
-      <Text>{unit}</Text>
+      </H1MediumText>
+      <H3Text>{unit}</H3Text>
     </HStack>
   );
 };

--- a/app/src/@shared/components/DashboardContentView/Rank/ProjectRankList.tsx
+++ b/app/src/@shared/components/DashboardContentView/Rank/ProjectRankList.tsx
@@ -10,7 +10,7 @@ type ProjectRankListProps = {
 
 export const ProjectRankList = ({ list, cnt, unit }: ProjectRankListProps) => {
   return (
-    <VStack w="100%" h="100%" spacing="2rem">
+    <VStack w="100%" h="100%" spacing="2.4rem">
       {list.slice(0, cnt).map((item) => (
         <ProjectRankListItem
           key={item.projectPreview.id}

--- a/app/src/@shared/components/DashboardContentView/Rank/RankListItem.tsx
+++ b/app/src/@shared/components/DashboardContentView/Rank/RankListItem.tsx
@@ -1,5 +1,11 @@
 import { useTheme } from '@emotion/react';
-import { H2BoldText, H3BoldText, HStack, MediumText } from '@shared/ui-kit';
+import {
+  Center,
+  H2MediumText,
+  H3MediumText,
+  HStack,
+  MediumText,
+} from '@shared/ui-kit';
 import { numberWithUnitFormatter } from '@shared/utils/formatters';
 import { Link } from 'react-router-dom';
 
@@ -25,22 +31,18 @@ export const RankListItem = ({
     rank === 1 ? theme.colors.accent.default : theme.colors.mono.black;
 
   return (
-    <HStack w="80%" spacing="2.4rem">
-      <H2BoldText color={color}>{rank}</H2BoldText>
+    <HStack w="90%" justify="start" spacing="2.4rem">
+      <Center w="2rem">
+        <H2MediumText color={color}>{rank}</H2MediumText>
+      </Center>
       {center}
-      <HStack
-        w="100%"
-        spacing="1rem"
-        align="baseline"
-        justify="start"
-        wrap="wrap"
-      >
+      <HStack spacing="1rem" align="baseline" justify="start" wrap="wrap">
         {link ? (
           <Link to={link}>
-            <H3BoldText color={color}>{name}</H3BoldText>
+            <H3MediumText color={color}>{name}</H3MediumText>
           </Link>
         ) : (
-          <H3BoldText color={color}>{name}</H3BoldText>
+          <H3MediumText color={color}>{name}</H3MediumText>
         )}
         <MediumText color={color}>
           {numberWithUnitFormatter(value, unit)}

--- a/app/src/@shared/components/DashboardContentView/Text/TextDefault.tsx
+++ b/app/src/@shared/components/DashboardContentView/Text/TextDefault.tsx
@@ -1,4 +1,4 @@
-import { H2BoldText } from '@shared/ui-kit';
+import { H2MediumText } from '@shared/ui-kit';
 import { Link } from 'react-router-dom';
 
 type TextDefaultProps = {
@@ -11,10 +11,10 @@ export const TextDefault = ({ text, link }: TextDefaultProps) => {
     <>
       {link !== undefined ? (
         <Link to={link}>
-          <H2BoldText style={{ textAlign: 'center' }}>{text}</H2BoldText>
+          <H2MediumText style={{ textAlign: 'center' }}>{text}</H2MediumText>
         </Link>
       ) : (
-        <H2BoldText style={{ textAlign: 'center' }}>{text}</H2BoldText>
+        <H2MediumText style={{ textAlign: 'center' }}>{text}</H2MediumText>
       )}
     </>
   );

--- a/app/src/@shared/components/DashboardSkeleton/Desktop/index.tsx
+++ b/app/src/@shared/components/DashboardSkeleton/Desktop/index.tsx
@@ -1,6 +1,5 @@
 import { DesktopDashboardLayout } from '@shared/components/Dashboard/Desktop';
 import { DesktopDashboardRow } from '@shared/components/Dashboard/Desktop/DesktopDashboardRow';
-import { DashboardItem } from '@shared/components/Dashboard/shared/DashboardItem';
 import type { DesktopDashboardProps } from '@shared/types/Dashboard';
 import { DashboardItemSkeleton } from '../shared/DashboardItemSkeleton';
 
@@ -14,13 +13,12 @@ export const DesktopDashboardSkeleton = ({
       {rows.map(({ row, col, items }, rowIdx) => (
         <DesktopDashboardRow key={rowIdx} row={row} col={col}>
           {items.map(({ row, col, rowSpan, colSpan }, itemIdx) => (
-            <DashboardItem
+            <DashboardItemSkeleton
               key={itemIdx}
               row={row}
               col={col}
               rowSpan={rowSpan}
               colSpan={colSpan}
-              content={DashboardItemSkeleton}
             />
           ))}
         </DesktopDashboardRow>

--- a/app/src/@shared/components/DashboardSkeleton/shared/DashboardItemSkeleton.tsx
+++ b/app/src/@shared/components/DashboardSkeleton/shared/DashboardItemSkeleton.tsx
@@ -1,15 +1,22 @@
 import styled from '@emotion/styled';
+import type { DashboardItemProps } from '@shared/components/Dashboard/shared/DashboardItem';
 import { Skeleton } from '@shared/ui-kit';
 
-export const DashboardItemSkeleton = () => {
+type DashboardItemSkeletonProps = Omit<DashboardItemProps, 'content'>;
+
+export const DashboardItemSkeleton = ({
+  ...props
+}: DashboardItemSkeletonProps) => {
   return (
-    <Layout>
+    <Layout {...props}>
       <Skeleton />
     </Layout>
   );
 };
 
-const Layout = styled.div`
-  width: 100%;
-  height: 100%;
+type LayoutProps = Omit<DashboardItemProps, 'content'>;
+
+const Layout = styled.div<LayoutProps>`
+  grid-column: ${({ col, colSpan }) => `${col} / span ${colSpan}`};
+  grid-row: ${({ row, rowSpan }) => `${row} / span ${rowSpan}`};
 `;

--- a/app/src/@shared/ui-kit-styled/CustomBox.tsx
+++ b/app/src/@shared/ui-kit-styled/CustomBox.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 export const CustomBox = styled.div`
   width: 100%;
   height: 100%;
-  border-radius: ${({ theme }) => theme.radius.sm};
+  border-radius: ${({ theme }) => theme.radius.md};
   transition: all 0.2s;
-  border: 1px solid ${({ theme }) => theme.colors.mono.gray50};
   background-color: ${({ theme }) => theme.colors.mono.white};
+  box-shadow: 4px 12px 30px 6px rgba(0, 0, 0, 0.09);
 
   &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.mono.gray100};
+    box-shadow: 4px 12px 30px 6px rgba(0, 0, 0, 0.18);
   }
 `;

--- a/app/src/@shared/ui-kit-styled/SkeletonAnimation.tsx
+++ b/app/src/@shared/ui-kit-styled/SkeletonAnimation.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
 export const SkeletonAnimation = styled.div`
-  background: #eeeeee;
-  background: linear-gradient(110deg, #eeeeee 8%, #f5f5f5 18%, #eeeeee 33%);
+  background: #f2f2f2;
+  background: linear-gradient(110deg, #f2f2f2 8%, #fbfbfb 18%, #f2f2f2 33%);
   background-size: 200% 100%;
   animation: 1.4s shine linear infinite;
 

--- a/app/src/@shared/ui-kit/Select/Select.tsx
+++ b/app/src/@shared/ui-kit/Select/Select.tsx
@@ -1,12 +1,13 @@
-import triangle_down from '@shared/assets/icon/triangle-down.svg';
 import styled from '@emotion/styled';
+import triangle_down from '@shared/assets/icon/triangle-down.svg';
 
 export const Select = styled.select`
   all: unset;
   padding: 1rem 2rem;
   border: 1px solid ${({ theme }) => theme.colors.mono.gray50};
   border-radius: ${({ theme }) => theme.radius.md};
-  background: url(${triangle_down}) no-repeat right 2rem center #f9f9f9;
+  background: ${({ theme }) =>
+    `url(${triangle_down}) no-repeat right 2rem center ${theme.colors.mono.white}`};
   background-size: 10px;
   user-select: none;
 

--- a/app/src/@shared/ui-kit/Skeleton/Skeleton.tsx
+++ b/app/src/@shared/ui-kit/Skeleton/Skeleton.tsx
@@ -10,5 +10,5 @@ type SkeletonProps = Partial<{
 export const Skeleton = styled(SkeletonAnimation)<SkeletonProps>`
   width: ${({ w = '100%' }) => w};
   height: ${({ h = '100%' }) => h};
-  border-radius: ${({ theme, radius = theme.radius.sm }) => radius};
+  border-radius: ${({ theme, radius = theme.radius.md }) => radius};
 `;

--- a/app/src/@shared/ui-kit/Text/Text.tsx
+++ b/app/src/@shared/ui-kit/Text/Text.tsx
@@ -15,6 +15,25 @@ export const Text = styled.p<TextProps>`
   user-select: ${({ preventSelect }) => preventSelect && 'none'};
 `;
 
+export const TitleThinText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.thin};
+`;
+
+export const TitleText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+`;
+
+export const TitleMediumText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.medium};
+`;
+
+export const TitleBoldText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.bold};
+`;
+
 export const H1ThinText = styled(Text)`
   font-size: ${({ theme }) => theme.fonts.size.h1};
   font-weight: ${({ theme }) => theme.fonts.weight.thin};
@@ -102,6 +121,29 @@ export const CaptionMediumText = styled(Text)`
 export const CaptionBoldText = styled(Text)`
   font-size: ${({ theme }) => theme.fonts.size.caption};
   font-weight: ${({ theme }) => theme.fonts.weight.bold};
+`;
+
+export const PrimaryTitleThinText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.thin};
+  color: ${({ theme }) => theme.colors.primary.default};
+`;
+
+export const PrimaryTitleText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  color: ${({ theme }) => theme.colors.primary.default};
+`;
+
+export const PrimaryTitleMediumText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.medium};
+  color: ${({ theme }) => theme.colors.primary.default};
+`;
+
+export const PrimaryTitleBoldText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.bold};
+  color: ${({ theme }) => theme.colors.primary.default};
 `;
 
 export const PrimaryH1ThinText = styled(Text)`
@@ -215,6 +257,28 @@ export const PrimaryCaptionBoldText = styled(Text)`
   font-weight: ${({ theme }) => theme.fonts.weight.bold};
   color: ${({ theme }) => theme.colors.primary.default};
 `;
+export const AccentTitleThinText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.thin};
+  color: ${({ theme }) => theme.colors.accent.default};
+`;
+
+export const AccentTitleText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  color: ${({ theme }) => theme.colors.accent.default};
+`;
+
+export const AccentTitleMediumText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.medium};
+  color: ${({ theme }) => theme.colors.accent.default};
+`;
+
+export const AccentTitleBoldText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.bold};
+  color: ${({ theme }) => theme.colors.accent.default};
+`;
 
 export const AccentH1ThinText = styled(Text)`
   font-size: ${({ theme }) => theme.fonts.size.h1};
@@ -325,6 +389,29 @@ export const AccentCaptionBoldText = styled(Text)`
   font-size: ${({ theme }) => theme.fonts.size.caption};
   font-weight: ${({ theme }) => theme.fonts.weight.bold};
   color: ${({ theme }) => theme.colors.accent.default};
+`;
+
+export const WhiteTitleThinText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.thin};
+  color: ${({ theme }) => theme.colors.mono.white};
+`;
+
+export const WhiteTitleText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  color: ${({ theme }) => theme.colors.mono.white};
+`;
+
+export const WhiteTitleMediumText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.medium};
+  color: ${({ theme }) => theme.colors.mono.white};
+`;
+
+export const WhiteTitleBoldText = styled(Text)`
+  font-size: ${({ theme }) => theme.fonts.size.title};
+  font-weight: ${({ theme }) => theme.fonts.weight.bold};
+  color: ${({ theme }) => theme.colors.mono.white};
 `;
 
 export const WhiteH1ThinText = styled(Text)`

--- a/app/src/EvalLogSearch/components/EvalLogList.tsx
+++ b/app/src/EvalLogSearch/components/EvalLogList.tsx
@@ -8,7 +8,7 @@ type EvalLogListProps = {
 
 export const EvalLogList = ({ evalLogEdges }: EvalLogListProps) => {
   return (
-    <VStack as="ul" w="100%" spacing="2rem">
+    <VStack as="ul" w="100%" spacing="1rem">
       {evalLogEdges.map(({ node }) => (
         <EvalLogItem key={node.id} element={node} />
       ))}

--- a/app/src/EvalLogSearch/components/EvalLogSearchTitle.tsx
+++ b/app/src/EvalLogSearch/components/EvalLogSearchTitle.tsx
@@ -4,7 +4,7 @@ import { PrimaryBoldText, Text, VStack } from '@shared/ui-kit';
 
 type EvalLogSearchTitleProps = {
   form: EvalLogSearchModel;
-  totalCount: number;
+  totalCount?: number;
 };
 
 export const EvalLogSearchTitle = ({
@@ -23,7 +23,9 @@ export const EvalLogSearchTitle = ({
         form.sortOrder === 'desc' ? '최신 순' : '오래된 순'
       }`}</PrimaryBoldText>
       <Text color={theme.colors.mono.gray300}>
-        검색결과 {totalCount?.toLocaleString()}건
+        {totalCount === undefined
+          ? '검색 중...'
+          : `검색 결과 ${totalCount.toLocaleString()}건`}
       </Text>
     </VStack>
   );

--- a/app/src/EvalLogSearch/index.tsx
+++ b/app/src/EvalLogSearch/index.tsx
@@ -179,7 +179,7 @@ const EvalLogSearchPage = () => {
       <VStack w="100%" align="start" spacing="2rem">
         <EvalLogSearchTitle
           form={evalLogSearchForm}
-          totalCount={data?.getEvalLogs.pageInfo?.totalCount ?? 0}
+          totalCount={data?.getEvalLogs.pageInfo?.totalCount}
         />
         <EvalLogSearchResult
           evalLogEdges={evalLogEdges}

--- a/app/src/Home/dashboard-contents/MyInfo/Hero.tsx
+++ b/app/src/Home/dashboard-contents/MyInfo/Hero.tsx
@@ -9,7 +9,7 @@ import {
   Center,
   Loader,
   VStack,
-  WhiteH2BoldText,
+  WhiteH1BoldText,
   WhiteText,
 } from '@shared/ui-kit';
 import { timeDiffStringFormatter } from '@shared/utils/formatters/timeDiffStringFormatter';
@@ -124,7 +124,7 @@ export const Hero = () => {
   return (
     <Layout>
       <VStack w="100%" h="100%" align="start" spacing="1rem">
-        <WhiteH2BoldText>반가워요, {userPreview.login} 👋</WhiteH2BoldText>
+        <WhiteH1BoldText>반가워요, {userPreview.login} 👋</WhiteH1BoldText>
         <WhiteText>{getIndividualizedMessage()}</WhiteText>
       </VStack>
     </Layout>
@@ -134,7 +134,7 @@ export const Hero = () => {
 const Layout = styled(Center)`
   background-image: url(${space_background});
   background-size: cover;
-  border-radius: ${({ theme }) => theme.radius.sm};
+  border-radius: ${({ theme }) => theme.radius.md};
   padding: 0 4rem;
   height: 100%;
   user-select: none;

--- a/app/src/Home/dashboard-contents/Team/CurrRegisteredCountRanking.tsx
+++ b/app/src/Home/dashboard-contents/Team/CurrRegisteredCountRanking.tsx
@@ -7,7 +7,6 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { ProjectRankList } from '@shared/components/DashboardContentView/Rank/ProjectRankList';
-import { Mobile, TabletAndAbove } from '@shared/utils/react-responsive/Device';
 
 const GET_CURR_REGISTERED_COUNT_RANKING = gql(/* GraphQL */ `
   query GetCurrRegisteredCountRanking($limit: Int!) {
@@ -44,20 +43,7 @@ export const CurrRegisteredCountRanking = () => {
 
   return (
     <DashboardContent title={title}>
-      <TabletAndAbove>
-        <ProjectRankList
-          list={currRegisteredCountRanking}
-          cnt={5}
-          unit={unit}
-        />
-      </TabletAndAbove>
-      <Mobile>
-        <ProjectRankList
-          list={currRegisteredCountRanking}
-          cnt={3}
-          unit={unit}
-        />
-      </Mobile>
+      <ProjectRankList list={currRegisteredCountRanking} cnt={5} unit={unit} />
     </DashboardContent>
   );
 };

--- a/app/src/Home/dashboard-contents/User/BlackholedCountPerCircle.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedCountPerCircle.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client';
-import { useTheme } from '@emotion/react';
 import { gql } from '@shared/__generated__';
 import { DonutChart } from '@shared/components/Chart';
 import { DashboardContent } from '@shared/components/DashboardContent';
@@ -56,17 +55,9 @@ const BlackholedCountPerCircleChart = ({
   labels,
   series,
 }: BlackholedCountPerCircleChartProps) => {
-  const theme = useTheme();
-
   const options: ApexCharts.ApexOptions = {
     legend: {
       show: false,
-    },
-    theme: {
-      monochrome: {
-        enabled: true,
-        color: theme.colors.primary.default,
-      },
     },
     tooltip: {
       enabled: false,

--- a/app/src/Home/dashboard-contents/User/CorrectionPointRanking.tsx
+++ b/app/src/Home/dashboard-contents/User/CorrectionPointRanking.tsx
@@ -7,7 +7,6 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { UserRankList } from '@shared/components/DashboardContentView/Rank/UserRankList';
-import { Mobile, TabletAndAbove } from '@shared/utils/react-responsive/Device';
 
 const GET_CORRECTION_POINT_RANKING = gql(/* GraphQL */ `
   query GetCorrectionPointRanking($limit: Int!) {
@@ -43,12 +42,7 @@ export const CorrectionPointRanking = () => {
 
   return (
     <DashboardContent title={title}>
-      <TabletAndAbove>
-        <UserRankList list={correctionPointRanking} cnt={5} unit={unit} />
-      </TabletAndAbove>
-      <Mobile>
-        <UserRankList list={correctionPointRanking} cnt={3} unit={unit} />
-      </Mobile>
+      <UserRankList list={correctionPointRanking} cnt={5} unit={unit} />
     </DashboardContent>
   );
 };

--- a/app/src/Home/dashboard-contents/User/WalletRanking.tsx
+++ b/app/src/Home/dashboard-contents/User/WalletRanking.tsx
@@ -7,7 +7,6 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { UserRankList } from '@shared/components/DashboardContentView/Rank/UserRankList';
-import { Mobile, TabletAndAbove } from '@shared/utils/react-responsive/Device';
 
 const GET_WALLET_RANKING = gql(/* GraphQL */ `
   query GetWalletRanking($limit: Int!) {
@@ -44,12 +43,7 @@ export const WalletRanking = () => {
 
   return (
     <DashboardContent title={title}>
-      <TabletAndAbove>
-        <UserRankList list={walletRanking} cnt={5} unit={unit} />
-      </TabletAndAbove>
-      <Mobile>
-        <UserRankList list={walletRanking} cnt={3} unit={unit} />
-      </Mobile>
+      <UserRankList list={walletRanking} cnt={5} unit={unit} />
     </DashboardContent>
   );
 };

--- a/app/src/Leaderboard/components/Leaderboard/LeaderboardListItem.tsx
+++ b/app/src/Leaderboard/components/Leaderboard/LeaderboardListItem.tsx
@@ -6,8 +6,7 @@ import {
   Avatar,
   CaptionText,
   Clickable,
-  H2BoldText,
-  H3BoldText,
+  H2MediumText,
   H3MediumText,
   HStack,
   MediumText,
@@ -49,17 +48,17 @@ export const LeaderboardListItem = ({
       <TabletAndAbove>
         <HStack w="100%" spacing="4rem">
           <HStack w="5rem">
-            <H3BoldText color={color}>{rank}</H3BoldText>
+            <H3MediumText color={color}>{rank}</H3MediumText>
           </HStack>
           <Avatar src={imgUrl} />
           <H3MediumText color={color}>{login}</H3MediumText>
           <Spacer />
           <HStack align="baseline" spacing="0.2rem">
-            <H2BoldText color={color}>
+            <H2MediumText color={color}>
               {fixedNumber === undefined
                 ? numberWithUnitFormatter(value)
                 : `${value.toFixed(2)}`}
-            </H2BoldText>
+            </H2MediumText>
             <Text color={color}>{unit}</Text>
           </HStack>
         </HStack>
@@ -73,11 +72,11 @@ export const LeaderboardListItem = ({
           <MediumText color={color}>{login}</MediumText>
           <Spacer />
           <HStack align="baseline" spacing="0.2rem">
-            <H3BoldText color={color}>
+            <H3MediumText color={color}>
               {fixedNumber === undefined
                 ? numberWithUnitFormatter(value)
                 : `${value.toFixed(2)}`}
-            </H3BoldText>
+            </H3MediumText>
             <CaptionText color={color}>{unit}</CaptionText>
           </HStack>
         </HStack>

--- a/app/src/Profile/dashboard-contents/Eval/DestinyRanking.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/DestinyRanking.tsx
@@ -7,7 +7,6 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { UserRankList } from '@shared/components/DashboardContentView/Rank/UserRankList';
-import { Mobile, TabletAndAbove } from '@shared/utils/react-responsive/Device';
 import { useParams } from 'react-router-dom';
 
 const GET_DESTINY_RANKING_BY_LOGIN = gql(/* GraphQL */ `
@@ -54,12 +53,7 @@ export const DestinyRanking = () => {
 
   return (
     <DashboardContent title={title} description={description}>
-      <TabletAndAbove>
-        <UserRankList list={destinyRanking} cnt={5} unit={unit} />
-      </TabletAndAbove>
-      <Mobile>
-        <UserRankList list={destinyRanking} cnt={3} unit={unit} />
-      </Mobile>
+      <UserRankList list={destinyRanking} cnt={5} unit={unit} />
     </DashboardContent>
   );
 };

--- a/app/src/Profile/dashboard-contents/General/BeginAt.tsx
+++ b/app/src/Profile/dashboard-contents/General/BeginAt.tsx
@@ -5,7 +5,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { H2BoldText, H3Text, HStack } from '@shared/ui-kit';
+import { H2MediumText, H3Text, HStack } from '@shared/ui-kit';
 import { dDayFormatter } from '@shared/utils/formatters';
 import dayjs from 'dayjs';
 import { useParams } from 'react-router-dom';
@@ -37,7 +37,7 @@ export const BeginAt = () => {
   return (
     <DashboardContent title={title}>
       <HStack spacing="1rem" align="baseline">
-        <H2BoldText>{dayjs(beginAt).format('YYYY. MM. DD.')}</H2BoldText>
+        <H2MediumText>{dayjs(beginAt).format('YYYY. MM. DD.')}</H2MediumText>
         <H3Text>{dDayFormatter(new Date(beginAt))}</H3Text>
       </HStack>
     </DashboardContent>

--- a/app/src/Profile/dashboard-contents/General/Character/index.tsx
+++ b/app/src/Profile/dashboard-contents/General/Character/index.tsx
@@ -6,7 +6,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { H3BoldText, HStack, Image, Label, VStack } from '@shared/ui-kit';
+import { H3MediumText, HStack, Image, Label, VStack } from '@shared/ui-kit';
 import { useParams } from 'react-router-dom';
 
 const GET_CHARACTER_BY_LOGIN = gql(/* GraphQL */ `
@@ -65,7 +65,7 @@ export const Character = () => {
               </Label>
             ))}
           </HStack>
-          <H3BoldText>{name ?? ''}</H3BoldText>
+          <H3MediumText>{name ?? ''}</H3MediumText>
         </VStack>
       </VStack>
     </DashboardContent>

--- a/app/src/Profile/dashboard-contents/General/CoalitionScore.tsx
+++ b/app/src/Profile/dashboard-contents/General/CoalitionScore.tsx
@@ -6,7 +6,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { H1BoldText, H3Text, HStack } from '@shared/ui-kit';
+import { H1MediumText, H3Text, HStack } from '@shared/ui-kit';
 import { useParams } from 'react-router-dom';
 import { GET_PERSONAL_GENERAL_ZERO_COST_BY_LOGIN } from '../../dashboard-contents-queries/GET_PERSONAL_GENERAL_ZERO_COST_BY_LOGIN';
 
@@ -39,7 +39,7 @@ export const CoalitionScore = () => {
   return (
     <DashboardContent title={title}>
       <HStack spacing="2rem" align="baseline">
-        <H1BoldText>{value.toLocaleString()}</H1BoldText>
+        <H1MediumText>{value.toLocaleString()}</H1MediumText>
         <HStack spacing="0.5rem">
           <CoalitionMark size="18px" coalition={coalition} />
           {scoreInfo?.rankInCoalition ? (

--- a/app/src/Profile/dashboard-contents/General/PreferredTime.tsx
+++ b/app/src/Profile/dashboard-contents/General/PreferredTime.tsx
@@ -9,7 +9,7 @@ import {
 } from '@shared/components/DashboardContentView/Error';
 import { ProgressionBar } from '@shared/components/ProgressionBar';
 import { TextMax } from '@shared/components/TextMax';
-import { H3BoldText, HStack, Text, VStack } from '@shared/ui-kit';
+import { H3MediumText, HStack, Text, VStack } from '@shared/ui-kit';
 import dayjs from 'dayjs';
 import { useParams } from 'react-router-dom';
 
@@ -116,7 +116,7 @@ export const PreferredTime = () => {
   return (
     <DashboardContent title={title} description={description}>
       <VStack spacing="4rem">
-        <H3BoldText>{getPreferredTimeTitle()}</H3BoldText>
+        <H3MediumText>{getPreferredTimeTitle()}</H3MediumText>
         <VStack spacing="1.5rem">
           {tableData.map(({ time, hour, minute, value }) => (
             <HStack key={time} spacing="2rem">

--- a/app/src/Profile/dashboard-contents/Profile/UserProfile/UserProfile.tsx
+++ b/app/src/Profile/dashboard-contents/Profile/UserProfile/UserProfile.tsx
@@ -161,7 +161,7 @@ const Layout = styled.div<LayoutProps>`
     `url(${backgroundUrl}), url(${backgroundFallbackUrl})`};
   background-size: cover;
   background-position: center;
-  border-radius: ${({ theme }) => theme.radius.sm};
+  border-radius: ${({ theme }) => theme.radius.md};
   user-select: none;
 `;
 
@@ -170,5 +170,5 @@ const UserProfileLoader = styled.div`
   background-image: url(${coalition_gray_cover});
   background-size: cover;
   background-position: center;
-  border-radius: ${({ theme }) => theme.radius.sm};
+  border-radius: ${({ theme }) => theme.radius.md};
 `;

--- a/app/src/Profile/dashboard-frames/profileGeneralTabDashboardRows.ts
+++ b/app/src/Profile/dashboard-frames/profileGeneralTabDashboardRows.ts
@@ -248,7 +248,7 @@ export const profileGeneralTabTabletDashboardRows: TabletDashboardRowType[] = [
 
 export const profileGeneralTabMobileDashboardRows: MobileDashboardRowType[] = [
   {
-    row: 19,
+    row: 17,
     col: 1,
     items: [
       {
@@ -303,33 +303,33 @@ export const profileGeneralTabMobileDashboardRows: MobileDashboardRowType[] = [
       {
         row: 9,
         col: 1,
-        rowSpan: 3,
+        rowSpan: 2,
         colSpan: 1,
         elementId: 9,
       },
       {
-        row: 12,
+        row: 11,
         col: 1,
         rowSpan: 3,
         colSpan: 1,
         elementId: 11,
       },
       {
-        row: 15,
+        row: 14,
         col: 1,
-        rowSpan: 3,
+        rowSpan: 2,
         colSpan: 1,
         elementId: 10,
       },
       {
-        row: 18,
+        row: 16,
         col: 1,
         rowSpan: 1,
         colSpan: 1,
         elementId: 5,
       },
       {
-        row: 19,
+        row: 17,
         col: 1,
         rowSpan: 1,
         colSpan: 1,

--- a/app/src/Setting/index.tsx
+++ b/app/src/Setting/index.tsx
@@ -1,16 +1,18 @@
 import { Seo } from '@shared/components/Seo';
 import { withFooter } from '@shared/hoc/withFooter';
 import { withHead } from '@shared/hoc/withHead';
-import { H1BoldText, VStack } from '@shared/ui-kit';
+import { TitleBoldText, VStack } from '@shared/ui-kit';
 import { AccountSection } from './sections/AccountSection';
 import { LinkGoogleSection } from './sections/LinkGoogleSection';
 
 const SettingPage = () => {
   return (
-    <VStack align="start" spacing="2rem">
-      <H1BoldText style={{ marginLeft: '2rem' }}>설정</H1BoldText>
-      <LinkGoogleSection />
-      <AccountSection />
+    <VStack w="100%" align="start" spacing="3rem">
+      <TitleBoldText style={{ marginLeft: '2rem' }}>설정</TitleBoldText>
+      <VStack w="100%" align="start" spacing="1rem">
+        <LinkGoogleSection />
+        <AccountSection />
+      </VStack>
     </VStack>
   );
 };


### PR DESCRIPTION
## Summary

box-shadow를 추가하여 Theme을 약간 수정하였습니다.

## Describe your changes

### 기존 (홈)
<img width="1440" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/23969abe-71e9-4b30-bede-cec316717b2c">

### 수정 (홈)
<img width="1440" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/6c7fdadf-c513-4d00-a69f-9de1eed7c698">

### 기존 (차트)
<img width="1144" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/1de35678-ecb4-4277-9117-4a32f404e7dd">

### 수정 (차트)
<img width="1143" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/2d782881-0b01-4184-8d32-e530ba560fa1">

### 기존 (내 정보 - 태블릿)
<img width="1019" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/af84347e-3d1b-4f7b-a8a2-018a0fc0aff8">

### 수정 (내 정보 - 태블릿)
<img width="1020" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/4dbd8438-170a-4ece-afb3-558db1f4e798">

## TODO
- [ ] fontSize 계층 마련 (모바일일 때는 같은 h1을 다른 사이즈로 이어주는 식으로 제작해야 할듯)

## Issue number and link
