### PR TITLE
🐛 fix: TeamInfoTable 글자의 너비가 클 때 발생하는 버그

### DIFF
--- a/app/src/Profile/dashboard-contents/General/TeamInfo/TeamInfoTable.tsx
+++ b/app/src/Profile/dashboard-contents/General/TeamInfo/TeamInfoTable.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { UserTeam } from '@shared/__generated__/graphql';
 import { ROUTES } from '@shared/constants/ROUTES';
 import { PrimaryText, Text } from '@shared/ui-kit';
-import { truncate } from 'lodash-es';
 import { Link } from 'react-router-dom';
 import { DateDiffWithStatus } from './DateDiffWithStatus';
 import { ResultWithStatus } from './ResultWithStatus';
@@ -47,7 +46,7 @@ export const TeamInfoTable = ({ teams }: TeamInfoTableProps) => {
                 <Text>{occurrence + 1}</Text>
               </td>
               <td>
-                <Text>{truncate(name, { length: 42 })}</Text>
+                <Text>{name}</Text>
               </td>
               <td>
                 <DateDiffWithStatus
@@ -82,6 +81,8 @@ const Table = styled.table`
   }
 
   td {
+    max-width: 300px;
+    overflow-x: hidden;
     text-align: center;
     padding: 0.4rem 2rem;
     vertical-align: middle;


### PR DESCRIPTION
## Summary

## Describe your changes

jiychoi

![image](https://github.com/42Statistics/42Stat-Frontend/assets/61629480/e7cdd95c-5d6a-4fda-ada4-3a411962469f)

- text-overflow: ellipsis 써서 overflow일 때 `...` 표시하고 싶었는데 잘 안돼서 일단 넘깁니다. 

jkong

![image](https://github.com/42Statistics/42Stat-Frontend/assets/61629480/9b39ba0b-a11a-4983-a4b3-da309b6a880f)

## Issue number and link
- close #122