### PR TITLE
🐛 [BugFix] localhost https -> http (백엔드 localhost와 호환)

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -4,33 +4,57 @@ import * as path from 'path';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
+const alias = [
+  {
+    find: '@core',
+    replacement: path.resolve(__dirname, 'src/@core'),
+  },
+  {
+    find: '@shared',
+    replacement: path.resolve(__dirname, 'src/@shared'),
+  },
+  { find: '@', replacement: path.resolve(__dirname, 'src') },
+];
+
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => {
+  if (command === 'serve') {
+    return {
+      plugins: [react(), svgr()],
+      server: {
+        host: 'frontend',
+        port: 8080,
+      },
+      preview: {
+        host: 'localhost',
+        port: 8080,
+      },
+      build: {
+        sourcemap: true,
+      },
+      resolve: {
+        alias,
+      },
+      envDir: './env',
+    };
+  }
   // todo: ssl
-  plugins: [react(), basicSsl(), svgr()],
-  server: {
-    host: 'frontend',
-    port: 8080,
-  },
-  preview: {
-    host: 'localhost',
-    port: 8080,
-  },
-  build: {
-    sourcemap: true,
-  },
-  resolve: {
-    alias: [
-      {
-        find: '@core',
-        replacement: path.resolve(__dirname, 'src/@core'),
-      },
-      {
-        find: '@shared',
-        replacement: path.resolve(__dirname, 'src/@shared'),
-      },
-      { find: '@', replacement: path.resolve(__dirname, 'src') },
-    ],
-  },
-  envDir: './env',
+  return {
+    plugins: [react(), basicSsl(), svgr()],
+    server: {
+      host: 'frontend',
+      port: 8080,
+    },
+    preview: {
+      host: 'localhost',
+      port: 8080,
+    },
+    build: {
+      sourcemap: true,
+    },
+    resolve: {
+      alias,
+    },
+    envDir: './env',
+  };
 });


### PR DESCRIPTION
## Summary

#171 에서 Chrome과 달리 Safari에서 로그인이 작동하지 않는 버그가 있었습니다. 
확인 결과 https://localhost:8080 -> http://localhost/graphql 로 요청을 보내는 과정에서 http <-> https 차이가 있어 발생하는 문제였습니다. 


## Describe your changes

dev일 때는 http, production일 때는 https로 작동하는 방식으로 변경하였습니다. 

## Issue number and link
- close #171