### PR TITLE
🐛 fix: 리더보드 dateTemplate, pageNumber 변경시 queryString

### DIFF
--- a/app/src/@core/providers/ScrollToTop.tsx
+++ b/app/src/@core/providers/ScrollToTop.tsx
@@ -1,11 +1,12 @@
 import { PropsWithReactElementChildren } from '@shared/types/PropsWithChildren';
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 export const ScrollToTop = ({ children }: PropsWithReactElementChildren) => {
   const location = useLocation();
+  const [searchParams] = useSearchParams();
 
-  useEffect(() => window.scrollTo(0, 0), [location.pathname]);
+  useEffect(() => window.scrollTo(0, 0), [location.pathname, searchParams]);
 
   return <>{children}</>;
 };

--- a/app/src/@shared/components/Pagination/index.tsx
+++ b/app/src/@shared/components/Pagination/index.tsx
@@ -26,9 +26,9 @@ export const Pagination = ({
     (_, i) => start + i,
   );
 
+  const isStartButtonDisabled = currPageNumber === 1;
   const isBackButtonDisabled = start === 1;
   const isForwardButtonDisabled = pageNumberList.includes(totalPageNumber);
-  const isStartButtonDisabled = currPageNumber === 1;
   const isEndButtonDisabled = currPageNumber === totalPageNumber;
 
   const handleClickBackButton = () => {
@@ -49,6 +49,10 @@ export const Pagination = ({
   const handleClickEndButton = () => {
     setPageNumber(totalPageNumber);
   };
+
+  if (totalPageNumber === 0) {
+    return null;
+  }
 
   return (
     <HStack spacing="1rem">

--- a/app/src/Leaderboard/tabs/CoalitionScore/index.tsx
+++ b/app/src/Leaderboard/tabs/CoalitionScore/index.tsx
@@ -1,3 +1,11 @@
+import {
+  parseDateTemplate,
+  stringifyDateTemplate,
+} from '@/Leaderboard/utils/parseDateTemplate';
+import {
+  parsePageNumber,
+  stringifyPageNumber,
+} from '@/Leaderboard/utils/parsePageNumber';
 import { useLazyQuery } from '@apollo/client';
 import { gql } from '@shared/__generated__';
 import { DateTemplate } from '@shared/__generated__/graphql';
@@ -6,6 +14,7 @@ import { useSegmentedControl } from '@shared/hooks/useSegmentedControl';
 import { SegmentedControl, VStack } from '@shared/ui-kit';
 import { useDeviceType } from '@shared/utils/react-responsive/useDeviceType';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { LeaderboardCoalitionScoreTabResult } from './LeaderboardCoalitionScoreTabResult';
 
 const GET_LEADERBOARD_COALITION_SCORE = gql(/* GraphQL */ `
@@ -52,10 +61,13 @@ const LeaderboardCoalitionScoreTab = () => {
   const SIZE_PER_PAGE = 50;
   const device = useDeviceType();
   const [search, result] = useLazyQuery(GET_LEADERBOARD_COALITION_SCORE);
-  const [pageNumber, setPageNumber] = useState<number>(1);
   const [totalPage, setTotalPage] = useState<number>(0);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
-    DateTemplate.CurrWeek,
+    parseDateTemplate(searchParams.get('dateTemplate'), DateTemplate.CurrWeek),
+  );
+  const [pageNumber, setPageNumber] = useState<number>(
+    parsePageNumber(searchParams.get('pageNumber')),
   );
 
   const options = [
@@ -102,7 +114,11 @@ const LeaderboardCoalitionScoreTab = () => {
         dateTemplate,
       },
     });
-  }, [dateTemplate, pageNumber, search]);
+    setSearchParams({
+      dateTemplate: stringifyDateTemplate(dateTemplate),
+      pageNumber: stringifyPageNumber(pageNumber),
+    });
+  }, [dateTemplate, search, pageNumber, setSearchParams]);
 
   useEffect(() => {
     setPageNumber(1);

--- a/app/src/Leaderboard/tabs/EvalCount/index.tsx
+++ b/app/src/Leaderboard/tabs/EvalCount/index.tsx
@@ -1,3 +1,11 @@
+import {
+  parseDateTemplate,
+  stringifyDateTemplate,
+} from '@/Leaderboard/utils/parseDateTemplate';
+import {
+  parsePageNumber,
+  stringifyPageNumber,
+} from '@/Leaderboard/utils/parsePageNumber';
 import { useLazyQuery } from '@apollo/client';
 import { gql } from '@shared/__generated__';
 import { DateTemplate } from '@shared/__generated__/graphql';
@@ -6,6 +14,7 @@ import { useSegmentedControl } from '@shared/hooks/useSegmentedControl';
 import { SegmentedControl, VStack } from '@shared/ui-kit';
 import { useDeviceType } from '@shared/utils/react-responsive/useDeviceType';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { LeaderboardEvalCountTabResult } from './LeaderboardEvalCountTabResult';
 
 const GET_LEADERBOARD_EVAL_COUNT = gql(/* GraphQL */ `
@@ -52,10 +61,13 @@ const LeaderboardEvalCountTab = () => {
   const SIZE_PER_PAGE = 50;
   const device = useDeviceType();
   const [search, result] = useLazyQuery(GET_LEADERBOARD_EVAL_COUNT);
-  const [pageNumber, setPageNumber] = useState<number>(1);
   const [totalPage, setTotalPage] = useState<number>(0);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
-    DateTemplate.CurrWeek,
+    parseDateTemplate(searchParams.get('dateTemplate'), DateTemplate.CurrWeek),
+  );
+  const [pageNumber, setPageNumber] = useState<number>(
+    parsePageNumber(searchParams.get('pageNumber')),
   );
 
   const options = [
@@ -102,7 +114,15 @@ const LeaderboardEvalCountTab = () => {
         dateTemplate,
       },
     });
-  }, [dateTemplate, pageNumber, search]);
+    setSearchParams({
+      dateTemplate: stringifyDateTemplate(dateTemplate),
+      pageNumber: stringifyPageNumber(pageNumber),
+    });
+  }, [dateTemplate, search, pageNumber, setSearchParams]);
+
+  useEffect(() => {
+    setPageNumber(1);
+  }, [dateTemplate]);
 
   return (
     <VStack w="100%" spacing="6rem">

--- a/app/src/Leaderboard/tabs/ExpIncrement/index.tsx
+++ b/app/src/Leaderboard/tabs/ExpIncrement/index.tsx
@@ -1,3 +1,11 @@
+import {
+  parseDateTemplate,
+  stringifyDateTemplate,
+} from '@/Leaderboard/utils/parseDateTemplate';
+import {
+  parsePageNumber,
+  stringifyPageNumber,
+} from '@/Leaderboard/utils/parsePageNumber';
 import { useLazyQuery } from '@apollo/client';
 import { gql } from '@shared/__generated__';
 import { DateTemplate } from '@shared/__generated__/graphql';
@@ -6,6 +14,7 @@ import { useSegmentedControl } from '@shared/hooks/useSegmentedControl';
 import { SegmentedControl, VStack } from '@shared/ui-kit';
 import { useDeviceType } from '@shared/utils/react-responsive/useDeviceType';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { LeaderboardExpIncrementTabResult } from './LeaderboardExpIncrementTabResult';
 
 const GET_LEADERBOARD_EXP_INCREMENT = gql(/* GraphQL */ `
@@ -52,10 +61,13 @@ const LeaderboardExpIncrementTab = () => {
   const SIZE_PER_PAGE = 50;
   const device = useDeviceType();
   const [search, result] = useLazyQuery(GET_LEADERBOARD_EXP_INCREMENT);
-  const [pageNumber, setPageNumber] = useState<number>(1);
   const [totalPage, setTotalPage] = useState<number>(0);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
-    DateTemplate.CurrWeek,
+    parseDateTemplate(searchParams.get('dateTemplate'), DateTemplate.CurrWeek),
+  );
+  const [pageNumber, setPageNumber] = useState<number>(
+    parsePageNumber(searchParams.get('pageNumber')),
   );
 
   const options = [
@@ -97,7 +109,11 @@ const LeaderboardExpIncrementTab = () => {
         dateTemplate,
       },
     });
-  }, [dateTemplate, pageNumber, search]);
+    setSearchParams({
+      dateTemplate: stringifyDateTemplate(dateTemplate),
+      pageNumber: stringifyPageNumber(pageNumber),
+    });
+  }, [dateTemplate, search, pageNumber, setSearchParams]);
 
   useEffect(() => {
     setPageNumber(1);

--- a/app/src/Leaderboard/tabs/Level/index.tsx
+++ b/app/src/Leaderboard/tabs/Level/index.tsx
@@ -1,3 +1,11 @@
+import {
+  parseDateTemplate,
+  stringifyDateTemplate,
+} from '@/Leaderboard/utils/parseDateTemplate';
+import {
+  parsePageNumber,
+  stringifyPageNumber,
+} from '@/Leaderboard/utils/parsePageNumber';
 import { useLazyQuery } from '@apollo/client';
 import { gql } from '@shared/__generated__';
 import { DateTemplate } from '@shared/__generated__/graphql';
@@ -6,6 +14,7 @@ import { useSegmentedControl } from '@shared/hooks/useSegmentedControl';
 import { SegmentedControl, VStack } from '@shared/ui-kit';
 import { useDeviceType } from '@shared/utils/react-responsive/useDeviceType';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { LeaderboardLevelTabResult } from './LeaderboardLevelTabResult';
 
 const GET_LEADERBOARD_LEVEL = gql(/* GraphQL */ `
@@ -52,17 +61,22 @@ const LeaderboardLevelTab = () => {
   const SIZE_PER_PAGE = 50;
   const device = useDeviceType();
   const [search, result] = useLazyQuery(GET_LEADERBOARD_LEVEL);
-  const [pageNumber, setPageNumber] = useState<number>(1);
   const [totalPage, setTotalPage] = useState<number>(0);
-  const [dateTemplate, setDateTemplate] = useState<DateTemplate>(
-    DateTemplate.Total,
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [dateTemplate] = useState<DateTemplate>(
+    parseDateTemplate(searchParams.get('dateTemplate'), DateTemplate.Total),
   );
+  const [pageNumber, setPageNumber] = useState<number>(
+    parsePageNumber(searchParams.get('pageNumber')),
+  );
+
   const options = [
     {
       label: '누적',
       value: 'total',
     },
   ];
+
   const { controlRef, segments } = useSegmentedControl(options);
 
   useEffect(() => {
@@ -83,8 +97,15 @@ const LeaderboardLevelTab = () => {
         dateTemplate,
       },
     });
-    setPageNumber(pageNumber);
-  }, [dateTemplate, search, pageNumber]);
+    setSearchParams({
+      dateTemplate: stringifyDateTemplate(dateTemplate),
+      pageNumber: stringifyPageNumber(pageNumber),
+    });
+  }, [dateTemplate, search, pageNumber, setSearchParams]);
+
+  useEffect(() => {
+    setPageNumber(1);
+  }, [dateTemplate]);
 
   return (
     <VStack w="100%" spacing="6rem">

--- a/app/src/Leaderboard/utils/parseDateTemplate.ts
+++ b/app/src/Leaderboard/utils/parseDateTemplate.ts
@@ -1,0 +1,29 @@
+import { DateTemplate } from '@shared/__generated__/graphql';
+
+export const parseDateTemplate = (
+  str: string | null,
+  defaultValue: DateTemplate,
+) => {
+  switch (str) {
+    case 'weekly':
+      return DateTemplate.CurrWeek;
+    case 'monthly':
+      return DateTemplate.CurrMonth;
+    case 'total':
+      return DateTemplate.Total;
+    default:
+      return defaultValue;
+  }
+};
+
+export const stringifyDateTemplate = (dateTemplate: DateTemplate) => {
+  switch (dateTemplate) {
+    case DateTemplate.CurrWeek:
+      return 'weekly';
+    case DateTemplate.CurrMonth:
+      return 'monthly';
+    case DateTemplate.Total:
+    default:
+      return 'total';
+  }
+};

--- a/app/src/Leaderboard/utils/parsePageNumber.ts
+++ b/app/src/Leaderboard/utils/parsePageNumber.ts
@@ -1,0 +1,10 @@
+export const parsePageNumber = (str: string | null) => {
+  if (str === null) {
+    return 1;
+  }
+  return Number(str);
+};
+
+export const stringifyPageNumber = (pageNumber: number) => {
+  return String(pageNumber);
+};


### PR DESCRIPTION
## Summary
- `http://localhost:8080/leaderboard/level?dateTemplate=total&pageNumber=1` 형식으로 변경되었습니다. 
- scrollToTop 동작에 queryString 변화 조건을 추가하였습니다. 

## Describe your changes

## Issue number and link
- close #190 
- close #105