### PR TITLE
💄[Design] 차트 가독성 제고

### DIFF
--- a/app/src/@shared/components/Chart/DonutChart.tsx
+++ b/app/src/@shared/components/Chart/DonutChart.tsx
@@ -25,6 +25,12 @@ export const DonutChart = ({
         },
       },
     },
+    dataLabels: {
+      style: {
+        fontSize: '1.3rem',
+        fontWeight: 400,
+      },
+    },
     legend: {
       position: 'bottom',
     },

--- a/app/src/@shared/components/Chart/LineChart.tsx
+++ b/app/src/@shared/components/Chart/LineChart.tsx
@@ -17,7 +17,8 @@ export const LineChart = ({
   const lineChartOptions: ApexCharts.ApexOptions = {
     colors: [theme.colors.primary.default],
     stroke: {
-      width: 1.5,
+      curve: 'smooth',
+      width: 2.5,
     },
   };
 

--- a/app/src/@shared/components/Chart/PieChart.tsx
+++ b/app/src/@shared/components/Chart/PieChart.tsx
@@ -23,8 +23,14 @@ export const PieChart = ({
         // startAngle: -270,
         // endAngle: 90,
         dataLabels: {
-          offset: -15,
+          offset: -20,
         },
+      },
+    },
+    dataLabels: {
+      style: {
+        fontSize: '1.3rem',
+        fontWeight: 400,
       },
     },
     legend: {

--- a/app/src/@shared/components/Chart/options/defaultOptions.ts
+++ b/app/src/@shared/components/Chart/options/defaultOptions.ts
@@ -6,13 +6,8 @@ export const defaultOptions: ApexCharts.ApexOptions = {
     zoom: {
       enabled: false,
     },
-    // events: {
-    //   mounted: (chart) => {
-    //     chart.windowResizeHandler();
-    //   },
-    // },
-    // redrawOnParentResize: true,
-    // redrawOnWindowResize: true,
+    fontFamily:
+      "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif",
   },
   states: {
     hover: {

--- a/app/src/@shared/components/DashboardContentView/Rank/RankListItem.tsx
+++ b/app/src/@shared/components/DashboardContentView/Rank/RankListItem.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react';
 import { Body1Text, Center, H3Text, HStack, Text } from '@shared/ui-kit';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { Link } from 'react-router-dom';
 
 type RankListItemProps = {

--- a/app/src/@shared/constants/BREAKPOINT.ts
+++ b/app/src/@shared/constants/BREAKPOINT.ts
@@ -1,0 +1,4 @@
+export const BREAKPOINT = {
+  MOBILE: 768,
+  TABLET: 1280,
+};

--- a/app/src/@shared/utils/facepaint/mq.ts
+++ b/app/src/@shared/utils/facepaint/mq.ts
@@ -1,6 +1,7 @@
+import { BREAKPOINT } from '@shared/constants/BREAKPOINT';
 import facepaint from 'facepaint';
 
-const breakpoints = [768, 1280];
+const breakpoints = [BREAKPOINT.MOBILE, BREAKPOINT.TABLET];
 
 export const mq = facepaint(
   breakpoints.map((bp) => `@media(min-width: ${bp}px)`),

--- a/app/src/@shared/utils/formatters/index.ts
+++ b/app/src/@shared/utils/formatters/index.ts
@@ -1,5 +1,0 @@
-export * from './dDayFormatter';
-export * from './millionFormatter';
-export * from './numberWithUnitFormatter';
-export * from './snakeCaseFormatter';
-export * from './timeDiffStringFormatter';

--- a/app/src/@shared/utils/formatters/kiloFormatter.ts
+++ b/app/src/@shared/utils/formatters/kiloFormatter.ts
@@ -1,0 +1,7 @@
+export const kiloFormatter = (value: number, fixed = 2): string => {
+  if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(fixed)}M`;
+  } else {
+    return `${(value / 1000).toFixed(fixed)}K`;
+  }
+};

--- a/app/src/@shared/utils/formatters/millionFormatter.ts
+++ b/app/src/@shared/utils/formatters/millionFormatter.ts
@@ -1,3 +1,0 @@
-export const millionFormatter = (value: number, fixed = 2): string => {
-  return `${(value / 1000000).toFixed(fixed)}M`;
-};

--- a/app/src/@shared/utils/react-responsive/useDeviceType.ts
+++ b/app/src/@shared/utils/react-responsive/useDeviceType.ts
@@ -1,9 +1,14 @@
+import { BREAKPOINT } from '@shared/constants/BREAKPOINT';
 import type { Device } from '@shared/types/Device';
 import { useMediaQuery } from 'react-responsive';
 
-const useIsDesktop = () => useMediaQuery({ minWidth: 1280 });
-const useIsTablet = () => useMediaQuery({ minWidth: 768, maxWidth: 1279 });
-const useIsMobile = () => useMediaQuery({ maxWidth: 767 });
+const useIsDesktop = () => useMediaQuery({ minWidth: BREAKPOINT.TABLET });
+const useIsTablet = () =>
+  useMediaQuery({
+    minWidth: BREAKPOINT.MOBILE,
+    maxWidth: BREAKPOINT.TABLET - 1,
+  });
+const useIsMobile = () => useMediaQuery({ maxWidth: BREAKPOINT.MOBILE - 1 });
 
 export const useDeviceType = (): Device | null => {
   const isDesktop = useIsDesktop();

--- a/app/src/EvalLogSearch/components/FlagLabel/index.tsx
+++ b/app/src/EvalLogSearch/components/FlagLabel/index.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react';
-import { snakeCaseFormatter } from '@shared/utils/formatters';
+import { snakeCaseFormatter } from '@shared/utils/formatters/snakeCaseFormatter';
 import { EvalLogLabel } from '../EvalLogLabel';
 
 type FlagLabelProps = {

--- a/app/src/Home/dashboard-contents/Coalition/MonthlyTigCountPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/MonthlyTigCountPerCoalition.tsx
@@ -12,7 +12,7 @@ import {
 } from '@shared/components/DashboardContentView/Error';
 import { TextMax } from '@shared/components/TextMax';
 import { Body1Text, Center, VStack } from '@shared/ui-kit';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import dayjs from 'dayjs';
 import { capitalize } from 'lodash-es';
 

--- a/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
@@ -7,7 +7,8 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { kiloFormatter } from '@shared/utils/formatters/kiloFormatter';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_SCORE_RECORDS_PER_COALITION = gql(/* GraphQL */ `
   query GetScoreRecordsPerCoalition {
@@ -70,6 +71,14 @@ const ScoreRecordsPerCoalitionChart = ({
   series,
   colors,
 }: ScoreRecordsPerCoalitionChartProps) => {
+  const data = series.flatMap(
+    (elem) => elem.data as { x: number; y: number }[],
+  );
+  const [min, max] = [
+    Math.min(...data.map(({ y }) => y)),
+    Math.max(...data.map(({ y }) => y)),
+  ];
+
   const options: ApexCharts.ApexOptions = {
     chart: {
       width: '100%',
@@ -77,19 +86,26 @@ const ScoreRecordsPerCoalitionChart = ({
     xaxis: {
       type: 'datetime',
       labels: {
+        show: false,
         datetimeUTC: false,
         format: 'yy.MM.',
       },
     },
     colors: colors,
     yaxis: {
+      min: Math.floor(min / 10000) * 10000,
+      max: Math.ceil(max / 10000) * 10000,
       labels: {
-        formatter: (value) => numberWithUnitFormatter(value, 'P'),
+        formatter: (value) => kiloFormatter(value, 0),
       },
+      tickAmount: 4,
     },
     tooltip: {
       x: {
         format: 'yyyy년 M월',
+      },
+      y: {
+        formatter: (value) => numberWithUnitFormatter(value, 'P'),
       },
     },
   };

--- a/app/src/Home/dashboard-contents/Coalition/TotalScoresPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/TotalScoresPerCoalition.tsx
@@ -7,7 +7,8 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { millionFormatter } from '@shared/utils/formatters';
+import { kiloFormatter } from '@shared/utils/formatters/kiloFormatter';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_TOTAL_SCORES_PER_COALITION = gql(/* GraphQL */ `
   query GetTotalScoresPerCoalition {
@@ -49,7 +50,7 @@ export const TotalScoresPerCoalition = () => {
 
   const series: ApexAxisChartSeries = [
     {
-      name: 'Coalition 합산 점수',
+      name: '',
       data: seriesData,
     },
   ];
@@ -76,6 +77,9 @@ const TotalScoresPerCoalitionChart = ({
   series,
   colors,
 }: TotalScoresPerCoalitionChartProps) => {
+  const data = series[0].data as number[];
+  const [min, max] = [Math.min(...data), Math.max(...data)];
+
   const options: ApexCharts.ApexOptions = {
     plotOptions: {
       bar: {
@@ -83,20 +87,31 @@ const TotalScoresPerCoalitionChart = ({
         distributed: true,
       },
     },
-
+    legend: {
+      show: false,
+    },
     colors: colors,
-
     xaxis: {
       categories,
     },
     yaxis: {
-      min: 2500000,
+      min: Math.floor((min - (max + 50000 - min)) / 100000) * 100000, // 최솟값이 50%에 위치하도록
+      max: Math.ceil((max + 50000) / 100000) * 100000,
+      tickAmount: 4,
       labels: {
-        formatter: (value) => millionFormatter(value),
+        formatter: (value) => kiloFormatter(value, 2),
       },
     },
     dataLabels: {
-      formatter: (value) => millionFormatter(value as number), // FIXME: Type Assertion
+      formatter: (value) => kiloFormatter(value as number, 2), // FIXME: Type Assertion
+    },
+    tooltip: {
+      y: {
+        formatter: (value) => numberWithUnitFormatter(value, 'P'),
+      },
+      marker: {
+        show: false,
+      },
     },
   };
 

--- a/app/src/Home/dashboard-contents/Team/RecentExamResult.tsx
+++ b/app/src/Home/dashboard-contents/Team/RecentExamResult.tsx
@@ -72,7 +72,7 @@ export const RecentExamResult = () => {
 
   const series: ApexAxisChartSeries = [
     {
-      name: '통과율',
+      name: '',
       data: seriesData,
     },
   ];
@@ -108,7 +108,7 @@ const LastExamResultChart = ({
     xaxis: {
       categories,
       labels: {
-        formatter: (value) => `Rank ${String(value).padStart(2, '0')}`,
+        formatter: (value) => String(value).padStart(2, '0'),
       },
     },
     yaxis: {
@@ -118,11 +118,17 @@ const LastExamResultChart = ({
       },
     },
     tooltip: {
+      x: {
+        formatter: (value) => `Exam Rank ${String(value).padStart(2, '0')}`,
+      },
       y: {
         formatter: (value, { dataPointIndex }) =>
-          `${(value * 100).toFixed(1)}% (${seriesLabel[dataPointIndex].pass}/${
+          `${(value * 100).toFixed(1)}% (${
             seriesLabel[dataPointIndex].total
-          })`,
+          }명 중 ${seriesLabel[dataPointIndex].pass}명)`,
+      },
+      marker: {
+        show: false,
       },
     },
     dataLabels: {

--- a/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
@@ -7,7 +7,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_ALIVE_USER_COUNT_RECORDS = gql(/* GraphQL */ `
   query GetAliveUserCountRecords {
@@ -41,7 +41,7 @@ export const AliveUserCountRecords = () => {
   }));
   const series: ApexAxisChartSeries = [
     {
-      name: '여행 중인 유저',
+      name: '',
       data: seriesData,
     },
   ];
@@ -64,6 +64,7 @@ const ActiveUserCountRecordsChart = ({
     xaxis: {
       type: 'datetime',
       labels: {
+        show: false,
         format: 'yy.MM.',
       },
     },
@@ -78,6 +79,9 @@ const ActiveUserCountRecordsChart = ({
       },
       y: {
         formatter: (value) => numberWithUnitFormatter(value, '명'),
+      },
+      marker: {
+        show: false,
       },
     },
   };

--- a/app/src/Home/dashboard-contents/User/AverageDurationPerCircle.tsx
+++ b/app/src/Home/dashboard-contents/User/AverageDurationPerCircle.tsx
@@ -7,7 +7,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_AVERAGE_DURATION_PER_CIRCLE = gql(/* GraphQL */ `
   query GetAverageDurationPerCircle {
@@ -60,7 +60,7 @@ export const AverageDurationPerCircle = () => {
 
   const series: ApexAxisChartSeries = [
     {
-      name: '평균 체류 기간',
+      name: '이전 서클과의 차',
       data: seriesData,
     },
   ];
@@ -106,11 +106,13 @@ const AverageDurationPerCircleChart = ({
       },
     },
     tooltip: {
-      shared: false,
       y: {
         // formatter: (value) => numberWithUnitFormatter(value, '일'),
         formatter: (value, { dataPointIndex }) =>
           numberWithUnitFormatter(seriesLabel[dataPointIndex], '일'),
+      },
+      marker: {
+        show: false,
       },
     },
   };

--- a/app/src/Home/dashboard-contents/User/BlackholedCountPerCircle.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedCountPerCircle.tsx
@@ -7,7 +7,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_BLACKHOLED_COUNT_PER_CIRCLE = gql(/* GraphQL */ `
   query GetBlackholedCountPerCircle {

--- a/app/src/Home/dashboard-contents/User/BlackholedRate.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedRate.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client';
-import { useTheme } from '@emotion/react';
 import { gql } from '@shared/__generated__';
 import { PieChart } from '@shared/components/Chart';
 import { DashboardContent } from '@shared/components/DashboardContent';
@@ -8,7 +7,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { capitalize } from 'lodash-es';
 
 const GET_BLACKHOLED_RATE = gql(/* GraphQL */ `
@@ -60,7 +59,6 @@ const BlackholedRateChart = ({ labels, series }: BlackholedRateChartProps) => {
       y: {
         formatter: (value) => numberWithUnitFormatter(value, '명'),
       },
-      fillSeriesColor: false,
     },
   };
 

--- a/app/src/Home/dashboard-contents/User/MemberRate.tsx
+++ b/app/src/Home/dashboard-contents/User/MemberRate.tsx
@@ -7,7 +7,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { capitalize } from 'lodash-es';
 
 const GET_MEMBER_RATE = gql(/* GraphQL */ `
@@ -67,7 +67,6 @@ const MemberRateChart = ({ labels, series }: MemberRateChartProps) => {
       y: {
         formatter: (value) => numberWithUnitFormatter(value, '명'),
       },
-      fillSeriesColor: false,
     },
   };
 

--- a/app/src/Home/dashboard-contents/User/UserCountPerLevel.tsx
+++ b/app/src/Home/dashboard-contents/User/UserCountPerLevel.tsx
@@ -7,7 +7,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_USER_COUNT_PER_LEVEL = gql(/* GraphQL */ `
   query GetUserCountPerLevel {
@@ -41,7 +41,7 @@ export const UserCountPerLevel = () => {
 
   const series: ApexAxisChartSeries = [
     {
-      name: '인원수',
+      name: '',
       data: seriesData,
     },
   ];
@@ -81,7 +81,10 @@ const UserCountPerLevelChart = ({
     },
     tooltip: {
       x: {
-        formatter: (value) => `Level ${value}`,
+        formatter: (value) => `레벨 ${value}`,
+      },
+      marker: {
+        show: false,
       },
     },
   };

--- a/app/src/Leaderboard/components/Leaderboard/LeaderboardListItem.tsx
+++ b/app/src/Leaderboard/components/Leaderboard/LeaderboardListItem.tsx
@@ -15,7 +15,7 @@ import {
   Text,
 } from '@shared/ui-kit';
 import { mq } from '@shared/utils/facepaint/mq';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { Mobile, TabletAndAbove } from '@shared/utils/react-responsive/Device';
 import { useNavigate } from 'react-router-dom';
 

--- a/app/src/Profile/dashboard-contents/General/BeginAt.tsx
+++ b/app/src/Profile/dashboard-contents/General/BeginAt.tsx
@@ -6,10 +6,10 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { Body1Text, H3MediumText, HStack } from '@shared/ui-kit';
-import { dDayFormatter } from '@shared/utils/formatters';
 import dayjs from 'dayjs';
 import { useParams } from 'react-router-dom';
 import { GET_PERSONAL_GENERAL_ZERO_COST_BY_LOGIN } from '../../dashboard-contents-queries/GET_PERSONAL_GENERAL_ZERO_COST_BY_LOGIN';
+import { dDayFormatter } from '@shared/utils/formatters/dDayFormatter';
 
 export const BeginAt = () => {
   const { login } = useParams() as { login: string };

--- a/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
@@ -1,3 +1,4 @@
+import { padWithNullValues } from '@/Profile/utils/padWithNullValues';
 import { useQuery } from '@apollo/client';
 import { useTheme } from '@emotion/react';
 import { gql } from '@shared/__generated__';
@@ -8,6 +9,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { BREAKPOINT } from '@shared/constants/BREAKPOINT';
 import { useParams } from 'react-router-dom';
 
 const GET_LEVEL_RECORDS_BY_LOGIN = gql(/* GraphQL */ `
@@ -57,19 +59,26 @@ export const LevelRecords = () => {
   const { userLevelRecords, promoLevelRecords, promoMemberLevelRecords } =
     data.getPersonalGeneral;
 
-  const userLevelSeries = userLevelRecords.map(({ monthsPassed, level }) => ({
-    x: monthsPassed,
-    y: level,
-  }));
-  const promoLevelSeries = promoLevelRecords.map(({ monthsPassed, level }) => ({
-    x: monthsPassed,
-    y: level,
-  }));
-  const promoMemberLevelSeries = promoMemberLevelRecords.map(
-    ({ monthsPassed, level }) => ({
+  const userLevelSeries = padWithNullValues(
+    userLevelRecords.map(({ monthsPassed, level }) => ({
       x: monthsPassed,
       y: level,
-    }),
+    })),
+    25,
+  );
+  const promoLevelSeries = padWithNullValues(
+    promoLevelRecords.map(({ monthsPassed, level }) => ({
+      x: monthsPassed,
+      y: level,
+    })),
+    25,
+  );
+  const promoMemberLevelSeries = padWithNullValues(
+    promoMemberLevelRecords.map(({ monthsPassed, level }) => ({
+      x: monthsPassed,
+      y: level,
+    })),
+    25,
   );
 
   const series = [
@@ -82,7 +91,7 @@ export const LevelRecords = () => {
       data: promoLevelSeries,
     },
     {
-      name: '동일 기수 중 멤버 평균',
+      name: '동일 기수 멤버 평균',
       data: promoMemberLevelSeries,
     },
   ];
@@ -101,6 +110,17 @@ type LevelRecordsChartProps = {
 const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
   const theme = useTheme();
 
+  const mobileOptions: ApexCharts.ApexOptions = {
+    xaxis: {
+      tickAmount: 4,
+    },
+    yaxis: {
+      labels: {
+        show: false,
+      },
+    },
+  };
+
   const options: ApexCharts.ApexOptions = {
     colors: [
       theme.colors.primary.default,
@@ -108,20 +128,32 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
       theme.colors.accent.default,
     ],
     xaxis: {
+      min: 0,
+      max: 24,
+      tickAmount: 8,
       labels: {
-        formatter: (value) => `${value}`,
+        formatter: (value) => `${value}개월`,
       },
     },
     yaxis: {
       labels: {
-        formatter: (value) => `lv. ${value}`,
+        formatter: (value) => value.toFixed(0),
       },
     },
     tooltip: {
       x: {
         formatter: (value) => `${value}개월 차`,
       },
+      y: {
+        formatter: (value) => (value === null ? '미정' : value.toFixed(2)),
+      },
     },
+    responsive: [
+      {
+        breakpoint: BREAKPOINT.MOBILE,
+        options: mobileOptions,
+      },
+    ],
   };
 
   return <LineChart series={series} options={options} />;

--- a/app/src/Profile/dashboard-contents/General/TeamInfo/DateDiffWithStatus.tsx
+++ b/app/src/Profile/dashboard-contents/General/TeamInfo/DateDiffWithStatus.tsx
@@ -1,6 +1,6 @@
 import { TeamStatus } from '@shared/__generated__/graphql';
 import { Text } from '@shared/ui-kit';
-import { timeDiffStringFormatter } from '@shared/utils/formatters';
+import { timeDiffStringFormatter } from '@shared/utils/formatters/timeDiffStringFormatter';
 
 type DateDiffWithStatusProps = {
   date: Date;

--- a/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
@@ -1,3 +1,4 @@
+import { padWithNullValues } from '@/Profile/utils/padWithNullValues';
 import { useQuery } from '@apollo/client';
 import { useTheme } from '@emotion/react';
 import { gql } from '@shared/__generated__';
@@ -9,6 +10,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { BREAKPOINT } from '@shared/constants/BREAKPOINT';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router-dom';
 
@@ -60,14 +62,20 @@ export const LevelRecords = () => {
     data2: { userLevelRecords: myLevelRecords },
   } = data;
 
-  const levelSeries = levelRecords.map(({ monthsPassed, level }) => ({
-    x: monthsPassed,
-    y: level,
-  }));
-  const myLevelSeries = myLevelRecords.map(({ monthsPassed, level }) => ({
-    x: monthsPassed,
-    y: level,
-  }));
+  const levelSeries = padWithNullValues(
+    levelRecords.map(({ monthsPassed, level }) => ({
+      x: monthsPassed,
+      y: level,
+    })),
+    25,
+  );
+  const myLevelSeries = padWithNullValues(
+    myLevelRecords.map(({ monthsPassed, level }) => ({
+      x: monthsPassed,
+      y: level,
+    })),
+    25,
+  );
 
   const series = [
     {
@@ -94,23 +102,46 @@ type LevelRecordsChartProps = {
 const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
   const theme = useTheme();
 
+  const mobileOptions: ApexCharts.ApexOptions = {
+    xaxis: {
+      tickAmount: 4,
+    },
+    yaxis: {
+      labels: {
+        show: false,
+      },
+    },
+  };
+
   const options: ApexCharts.ApexOptions = {
     colors: [theme.colors.primary.default, theme.colors.accent.default],
     xaxis: {
+      min: 0,
+      max: 24,
+      tickAmount: 8,
       labels: {
-        formatter: (value) => `${value}`,
+        formatter: (value) => `${value}개월`,
       },
     },
     yaxis: {
       labels: {
-        formatter: (value) => `lv. ${value}`,
+        formatter: (value) => value.toFixed(0),
       },
     },
     tooltip: {
       x: {
         formatter: (value) => `${value}개월 차`,
       },
+      y: {
+        formatter: (value) => (value === null ? '미정' : value.toFixed(2)),
+      },
     },
+    responsive: [
+      {
+        breakpoint: BREAKPOINT.MOBILE,
+        options: mobileOptions,
+      },
+    ],
   };
 
   return <LineChart series={series} options={options} />;

--- a/app/src/Profile/dashboard-frames/profileGeneralTabDashboardRows.ts
+++ b/app/src/Profile/dashboard-frames/profileGeneralTabDashboardRows.ts
@@ -35,7 +35,7 @@ export const profileGeneralTabDashboardRows: DashboardRowType[] = [
     items: [
       {
         rowSpan: 2,
-        elementId: 8,
+        elementId: 11,
       },
     ],
   },
@@ -66,7 +66,7 @@ export const profileGeneralTabDashboardRows: DashboardRowType[] = [
     items: [
       {
         rowSpan: 2,
-        elementId: 11,
+        elementId: 8,
       },
     ],
   },

--- a/app/src/Profile/utils/padWithNullValues.ts
+++ b/app/src/Profile/utils/padWithNullValues.ts
@@ -1,0 +1,10 @@
+export const padWithNullValues = (
+  series: { x: number; y: number }[],
+  length: number,
+) => {
+  const concatArray = [...Array(length - series.length)].map((_, index) => ({
+    x: series.length + index,
+    y: null,
+  }));
+  return [...series, ...concatArray];
+};

--- a/app/src/Project/dashboard-contents/ValidatedRate.tsx
+++ b/app/src/Project/dashboard-contents/ValidatedRate.tsx
@@ -9,7 +9,7 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { H3Text } from '@shared/ui-kit';
-import { numberWithUnitFormatter } from '@shared/utils/formatters';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { useParams } from 'react-router-dom';
 
 const GET_VALIDATED_RATE_BY_PROJECT_NAME = gql(/* GraphQL */ `


### PR DESCRIPTION
## Summary
차트 가독성을 높였습니다. 

## Describe your changes

> 기존이 왼쪽, 수정이 오른쪽입니다. 

### 여행 중인 유저 레벨 분포
<img width="381" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/e924849e-93f0-48e2-982b-9a7a3bedc2d4">
<img width="382" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/bb6b9b37-b7ad-4610-88b4-3a0405a85ef2">

### 서클 별 평균 통과 기간
<img width="379" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/845fd113-abd7-48ba-97a7-bd5ae05b4a85">
<img width="385" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/f3a4c6c6-8e03-4a5f-94fe-538bc00d4b34">

### 블랙홀 유저 비율
- 차트 전체에 적용되는 폰트를 Pretendard로 변경하였습니다. PieChart에서 변화가 가장 두드러집니다.  

<img width="388" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/51986d78-b975-45f3-96c2-f47dde77a9ab">
<img width="376" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/91216dc5-074e-4ee5-b593-cd0d542d8c42">

### 직전 회차 시험 통과율
<img width="385" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/42abefa7-6fa8-4bea-9aac-18ececf44424">
<img width="383" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/91ac76e1-da9a-4e26-bf16-c886e59d29f3">

### 여행 중인 유저 수 추이
- 이 카드와 같이 datetime 류 차트에 대하여, `xlabel` 싱크가 도저히 안 맞아서 제거하였습니다. 
- 호버 시 아래 라벨 비슷하게 역할을 해주니까 이상하진 않다고 생각했습니다. 

<img width="381" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/7595efbf-ef7f-4cd0-96d4-76a3f0f4d151">
<img width="382" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/7cf1dff5-8ace-4e18-98e9-e5bac9cb5a5e">

### 역대 코알리숑 스코어 변동 추이
- LineChart의 선을 굵게하고, smooth로 변경하여 가독성을 높였습니다. 
- 위 카드와 동일하게 datetime 류 차트이므로 `xlabel`을 제거하였습니다. 
- 데이터 전체의 최소/최대값을 계산하여 min, max range를 조정하기 때문에 값 변화에 유동적으로 대응할 수 있습니다.  
<img width="1129" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/31dc036e-ccff-4365-b61b-878861171fc2">
<img width="1124" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/c1e727b4-c3ca-43e1-b226-d8a225fd9991">

### 누적 코알리숑 스코어 합산
- #188 에서 제기되었던 이슈로, 최소값을 50%로 위치하도록 min 값을 조정하였습니다. 
- 위에 표시되는 dataLabel이 잘 나오도록 max를 조정하였습니다. 위 카드와 동일하게 min, max 계산 과정에 데이터의 최소/최대값을 파악하는 로직이 들어가 있어 값 변화에 유동적으로 대응할 수 있습니다. 
<img width="387" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/7dacbf23-3dde-442d-b957-a8cc189f5bdf">
<img width="379" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/c9d5bf9a-bb23-49fa-a5d5-81a9fefce7e3">

### 레벨 증가 그래프
- #158 문제를 우회적으로 해결하는 방법을 찾아서 2년 이하 유저의 경우 뒤 쪽을 비우는 뷰를 다시 살렸습니다. 
- 오래 한 유저에 대해서는 [0...24] 개월차 정보가 모두 주어지지만, 아직 2년 정보가 다 주어지지 않은 경우 데이터 뒤에 `{ x: 13, y: null }`의 형식으로 x: 24까지 추가하는 방식으로 추가해줍니다. 이후 차트에서 null 값인 경우 '미정' 문자열을 표시하는 방식으로 해결하였습니다.  

<img width="1129" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/061868bb-64e2-467f-b104-f55f4eb04d94">
<img width="1131" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/bb137d4a-51c5-4424-897f-788604d5047a">

- Versus의 경우에 다음과 같이 표시됩니다. 
<img width="1136" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/6652e92b-7b28-4050-990b-b60dc32f5f66">


### 추가. 모바일 화면에서의 가독성 제고
- 근본적인 변화는 아닙니다만, yLabel 정보를 숨기거나 tickAmount를 줄이는 식으로 가독성을 조금 높였습니다. 
- 변경된 카드 이미지를 첨부합니다. 
- 코알리숑 스코어 변동 추이 : 60,000 -> 60K

<img width="460" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/7ced7e6d-ec51-478a-b81d-9271033e39e2">
<img width="464" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/9712c0ae-cda1-44bd-891b-e4ed026ae9d0">

- 레벨 증가 그래프 : Tablet 이상일 때는 xLabel이 3개월 단위로, Mobile일 때는 6개월 단위로 표시됩니다.  
<img width="450" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/ae569640-9f80-496a-881d-856e4c6f5cd5">
<img width="454" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/07202ec9-dbf0-4415-8029-b6129d329a8e">


## Issue number and link
- close #158 