### PR TITLE
💄 [Design] 대시보드 카드 description 정렬 등

### DIFF
--- a/app/src/@shared/components/Chart/HorizontalBarChart.tsx
+++ b/app/src/@shared/components/Chart/HorizontalBarChart.tsx
@@ -24,7 +24,7 @@ export const HorizontalBarChart = ({
       },
     },
     dataLabels: {
-      offsetX: 40,
+      offsetX: 37,
       style: {
         colors: [theme.colors.mono.gray300],
         fontWeight: 400,

--- a/app/src/@shared/components/Chart/options/defaultOptions.ts
+++ b/app/src/@shared/components/Chart/options/defaultOptions.ts
@@ -23,12 +23,4 @@ export const defaultOptions: ApexCharts.ApexOptions = {
       },
     },
   },
-  legend: {
-    onItemClick: {
-      toggleDataSeries: false,
-    },
-    onItemHover: {
-      highlightDataSeries: false,
-    },
-  },
 };

--- a/app/src/@shared/components/DashboardContent.tsx
+++ b/app/src/@shared/components/DashboardContent.tsx
@@ -1,19 +1,27 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { PropsWithReactElementChildren } from '@shared/types/PropsWithChildren';
-import { Body1MediumText, CaptionText, Center, VStack } from '@shared/ui-kit';
+import {
+  Body1MediumText,
+  CaptionText,
+  Center,
+  Scroll,
+  VStack,
+} from '@shared/ui-kit';
+
+type DashboardContentType = 'Default' | 'ApexCharts' | 'Scrollable';
 
 export type DashboardContentProps = PropsWithReactElementChildren<{
   title?: string;
   description?: string;
-  isApexChart?: boolean;
+  type?: DashboardContentType;
 }>;
 
 export const DashboardContent = ({
   title,
   description,
   children,
-  isApexChart = false,
+  type = 'Default',
 }: DashboardContentProps) => {
   const theme = useTheme();
 
@@ -28,11 +36,13 @@ export const DashboardContent = ({
             </CaptionText>
           ) : null}
         </VStack>
-        {!isApexChart ? (
-          <Center>{children}</Center>
-        ) : (
+        {type === 'Default' ? <Center>{children}</Center> : null}
+        {type === 'ApexCharts' ? (
           <ApexChartsContainer>{children}</ApexChartsContainer>
-        )}
+        ) : null}
+        {type === 'Scrollable' ? (
+          <ScrollableContainer>{children}</ScrollableContainer>
+        ) : null}
       </VStack>
     </Layout>
   );
@@ -42,6 +52,11 @@ const Layout = styled.div`
   width: 100%;
   height: 100%;
   padding: 2.4rem;
+`;
+
+const ScrollableContainer = styled(Scroll)`
+  width: 100%;
+  padding: 0 1rem;
 `;
 
 /**

--- a/app/src/@shared/components/DashboardContent.tsx
+++ b/app/src/@shared/components/DashboardContent.tsx
@@ -35,6 +35,9 @@ export const DashboardContent = ({
               {description}
             </CaptionText>
           ) : null}
+          {title && !description ? (
+            <Body1MediumText>&nbsp;</Body1MediumText>
+          ) : null}
         </VStack>
         {type === 'Default' ? <Center>{children}</Center> : null}
         {type === 'ApexCharts' ? (

--- a/app/src/@shared/components/DashboardContentView/Error/DashboardContentBadRequest.tsx
+++ b/app/src/@shared/components/DashboardContentView/Error/DashboardContentBadRequest.tsx
@@ -6,7 +6,7 @@ import {
 
 type DashboardContentBadRequestProps = {
   message?: string;
-} & Omit<DashboardContentProps, 'children' | 'isApexChart'>;
+} & Omit<DashboardContentProps, 'children' | 'type'>;
 
 export const DashboardContentBadRequest = ({
   message = 'Something Went Wrong',

--- a/app/src/@shared/components/DashboardContentView/Error/DashboardContentLoading.tsx
+++ b/app/src/@shared/components/DashboardContentView/Error/DashboardContentLoading.tsx
@@ -6,7 +6,7 @@ import { Loader } from '@shared/ui-kit';
 
 type DashboardContentLoadingProps = Omit<
   DashboardContentProps,
-  'children' | 'isApexChart'
+  'children' | 'type'
 >;
 
 export const DashboardContentLoading = ({

--- a/app/src/@shared/components/DashboardContentView/Error/DashboardContentNotFound.tsx
+++ b/app/src/@shared/components/DashboardContentView/Error/DashboardContentNotFound.tsx
@@ -6,7 +6,7 @@ import {
 
 type DashboardContentNotFoundProps = Omit<
   DashboardContentProps,
-  'children' | 'isApexChart'
+  'children' | 'type'
 >;
 
 export const DashboardContentNotFound = ({

--- a/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
@@ -56,7 +56,7 @@ export const ScoreRecordsPerCoalition = () => {
   });
 
   return (
-    <DashboardContent title={title} isApexChart>
+    <DashboardContent title={title} type="ApexCharts">
       <ScoreRecordsPerCoalitionChart series={series} colors={colors} />
     </DashboardContent>
   );

--- a/app/src/Home/dashboard-contents/Coalition/TotalScoresPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/TotalScoresPerCoalition.tsx
@@ -56,7 +56,7 @@ export const TotalScoresPerCoalition = () => {
   ];
 
   return (
-    <DashboardContent title={title} isApexChart>
+    <DashboardContent title={title} type="ApexCharts">
       <TotalScoresPerCoalitionChart
         categories={categories}
         series={series}

--- a/app/src/Home/dashboard-contents/Team/RecentExamResult.tsx
+++ b/app/src/Home/dashboard-contents/Team/RecentExamResult.tsx
@@ -78,7 +78,7 @@ export const RecentExamResult = () => {
   ];
 
   return (
-    <DashboardContent title={title} description={description} isApexChart>
+    <DashboardContent title={title} description={description} type="ApexCharts">
       <LastExamResultChart
         categories={categories}
         series={series}

--- a/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
@@ -47,7 +47,7 @@ export const AliveUserCountRecords = () => {
   ];
 
   return (
-    <DashboardContent title={title} isApexChart>
+    <DashboardContent title={title} type="ApexCharts">
       <ActiveUserCountRecordsChart series={series} />
     </DashboardContent>
   );

--- a/app/src/Home/dashboard-contents/User/AverageDurationPerCircle.tsx
+++ b/app/src/Home/dashboard-contents/User/AverageDurationPerCircle.tsx
@@ -66,7 +66,7 @@ export const AverageDurationPerCircle = () => {
   ];
 
   return (
-    <DashboardContent title={title} description={description} isApexChart>
+    <DashboardContent title={title} description={description} type="ApexCharts">
       <AverageDurationPerCircleChart
         categories={categories}
         series={series}

--- a/app/src/Home/dashboard-contents/User/BlackholedCountPerCircle.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedCountPerCircle.tsx
@@ -40,7 +40,7 @@ export const BlackholedCountPerCircle = () => {
   const series = blackholedCountPerCircle.map(({ value }) => value);
 
   return (
-    <DashboardContent title={title} isApexChart>
+    <DashboardContent title={title} type="ApexCharts">
       <BlackholedCountPerCircleChart labels={labels} series={series} />
     </DashboardContent>
   );

--- a/app/src/Home/dashboard-contents/User/BlackholedRate.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedRate.tsx
@@ -42,7 +42,7 @@ export const BlackholedRate = () => {
   const series = fields.map((field) => field.value);
 
   return (
-    <DashboardContent title={title} isApexChart>
+    <DashboardContent title={title} type="ApexCharts">
       <BlackholedRateChart labels={labels} series={series} />
     </DashboardContent>
   );

--- a/app/src/Home/dashboard-contents/User/MemberRate.tsx
+++ b/app/src/Home/dashboard-contents/User/MemberRate.tsx
@@ -50,7 +50,7 @@ export const MemberRate = () => {
   const series = fields.map((field) => field.value);
 
   return (
-    <DashboardContent title={title} description={description} isApexChart>
+    <DashboardContent title={title} description={description} type="ApexCharts">
       <MemberRateChart labels={labels} series={series} />
     </DashboardContent>
   );

--- a/app/src/Home/dashboard-contents/User/UserCountPerLevel.tsx
+++ b/app/src/Home/dashboard-contents/User/UserCountPerLevel.tsx
@@ -47,7 +47,7 @@ export const UserCountPerLevel = () => {
   ];
 
   return (
-    <DashboardContent title={title} isApexChart>
+    <DashboardContent title={title} type="ApexCharts">
       <UserCountPerLevelChart categories={categories} series={series} />
     </DashboardContent>
   );

--- a/app/src/Profile/dashboard-contents/Eval/RecentComment.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/RecentComment.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from '@apollo/client';
-import styled from '@emotion/styled';
+import { DashboardContent } from '@shared/components/DashboardContent';
 import {
   DashboardContentBadRequest,
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { H3BoldText, Scroll, Text, VStack } from '@shared/ui-kit';
+import { Text } from '@shared/ui-kit';
 import { useParams } from 'react-router-dom';
 import { GET_PERSONAL_EVAL_ZERO_COST_BY_LOGIN } from '../../dashboard-contents-queries/GET_PERSONAL_EVAL_ZERO_COST_BY_LOGIN';
 
@@ -32,30 +32,9 @@ export const RecentComment = () => {
 
   const { recentComment } = data.getPersonalEval; // FIXME: null일 수 있음.
 
-  // 내부에서 overflow가 발생하는 경우, div w='100%' h='100%'으로 밖을 감싸면 비정상적으로 작동함
   return (
-    <DashboardContentLayout>
-      <VStack w="100%" h="100%" spacing="2rem" align="start">
-        <VStack w="100%" align="start">
-          <H3BoldText>{title}</H3BoldText>
-        </VStack>
-        <Scroll>
-          <Layout>
-            <Text>{recentComment}</Text>
-          </Layout>
-        </Scroll>
-      </VStack>
-    </DashboardContentLayout>
+    <DashboardContent title={title} type="Scrollable">
+      <Text>{recentComment}</Text>
+    </DashboardContent>
   );
 };
-
-const DashboardContentLayout = styled.div`
-  width: 100%;
-  height: 100%;
-  padding: 2rem;
-`;
-
-const Layout = styled.div`
-  width: 100%;
-  padding: 0 1rem;
-`;

--- a/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
@@ -145,7 +145,7 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
         formatter: (value) => `${value}개월 차`,
       },
       y: {
-        formatter: (value) => (value === null ? '미정' : value.toFixed(2)),
+        formatter: (value) => (value === null ? '-' : value.toFixed(2)),
       },
     },
     responsive: [

--- a/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
@@ -97,7 +97,7 @@ export const LevelRecords = () => {
   ];
 
   return (
-    <DashboardContent title={title} description={description} isApexChart>
+    <DashboardContent title={title} description={description} type="ApexCharts">
       <LevelRecordsChart series={series} />
     </DashboardContent>
   );

--- a/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
@@ -89,7 +89,7 @@ export const LevelRecords = () => {
   ];
 
   return (
-    <DashboardContent title={title} description={description} isApexChart>
+    <DashboardContent title={title} description={description} type="ApexCharts">
       <LevelRecordsChart series={series} />
     </DashboardContent>
   );

--- a/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
@@ -133,7 +133,7 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
         formatter: (value) => `${value}개월 차`,
       },
       y: {
-        formatter: (value) => (value === null ? '미정' : value.toFixed(2)),
+        formatter: (value) => (value === null ? '-' : value.toFixed(2)),
       },
     },
     responsive: [

--- a/app/src/Profile/dashboard-contents/Versus/Rankings.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/Rankings.tsx
@@ -165,7 +165,7 @@ export const Rankings = () => {
   ];
 
   return (
-    <DashboardContent title={title} description={description} isApexChart>
+    <DashboardContent title={title} description={description} type="ApexCharts">
       <RankingsChart categories={categories} series={series} />
     </DashboardContent>
   );


### PR DESCRIPTION
## Summary

## Describe your changes

- #205

dataLabel xoffset을 줄이는 방식으로 해결

<img width="337" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/35ce4794-f6be-4c51-8fcf-ed6867d632da">

---

- #206 

DashboardContent에서 title은 있으나 description이 없는 경우에는 공백(&nbsp;)를 추가하여 정렬을 맞춤.   
(selection 하면 공백이 드래그되는게 조금 불편하긴 한데, 1.8rem보다 직관적인 것 같아 그렇게 작성하였습니다.)

<img width="667" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/35e07ae7-75f9-47c0-8633-462b6503b865">

---

- #207

해결 방법은 못 찾았지만, #206을 해결하면서 DashboardContent 높이가 낮아지면서 문제가 어느정도 나아졌습니다. 

<img width="352" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/f047cdfe-7549-43c9-a281-cd0e75aee96e">

---

- #213

DashboardContent에 type으로 'Default' | 'ApexCharts' | 'Scrollable'을 받게 하여 title, description 정보의 원천을 하나로 통일했습니다. 

<img width="737" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/ebb15c26-552e-4e1d-9d1f-f5d5212e6dd3">

---

- 추가로, 예전에 legend hover, click 시 효과를 없앴었는데, 굳이 없앨 필요가 없어서 되살렸습니다. 

<img width="967" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/19273451-3ccc-4dde-92b7-44162308661e">


## Issue number and link
- close #205 
- close #206
- close #207 
- close #213