### PR TITLE
🐛  fix: EvalLogSearchTitle 의 totalCount 가 query 의 error 나 loading 상태를 반영하도록 수정

### DIFF
--- a/app/src/EvalLogSearch/index.tsx
+++ b/app/src/EvalLogSearch/index.tsx
@@ -1,6 +1,10 @@
 import { useLazyQuery } from '@apollo/client';
 import { gql } from '@shared/__generated__';
-import { EvalLogEdge, EvalLogSortOrder } from '@shared/__generated__/graphql';
+import {
+  EvalLogEdge,
+  EvalLogSortOrder,
+  GetEvalLogsQuery,
+} from '@shared/__generated__/graphql';
 import { Seo } from '@shared/components/Seo';
 import { withHead } from '@shared/hoc/withHead';
 import { useDisclosure } from '@shared/hooks/useDisclosure';
@@ -179,7 +183,7 @@ const EvalLogSearchPage = () => {
       <VStack w="100%" align="start" spacing="2rem">
         <EvalLogSearchTitle
           form={evalLogSearchForm}
-          totalCount={data?.getEvalLogs.pageInfo?.totalCount}
+          totalCount={calculateTotalCount({ data, error, loading })}
         />
         <EvalLogSearchResult
           evalLogEdges={evalLogEdges}
@@ -206,6 +210,25 @@ const EvalLogSearchPage = () => {
 
 const Head = () => {
   return <Seo title="평가로그 검색기" />;
+};
+
+const calculateTotalCount = ({
+  data,
+  error,
+  loading,
+}: Pick<
+  ReturnType<typeof useLazyQuery<GetEvalLogsQuery>>[1],
+  'data' | 'error' | 'loading'
+>): number | undefined => {
+  if (loading) {
+    return undefined;
+  }
+
+  if (error) {
+    return 0;
+  }
+
+  return data?.getEvalLogs.pageInfo.totalCount ?? 0;
 };
 
 export default withHead(EvalLogSearchPage, Head);


### PR DESCRIPTION
## Summary
EvalLogSearchTitle 의 totalCount 가 query 의 error 나 loading 상태를 반영하도록 수정

애초에 백엔드에서 같은 상황에 다른 결과를 반환하여 생기는 문제라고 판단하여,
백엔드 api 도 현재는 둘 다 빈 배열을 반환하도록 수정된 상태 입니다.
단, 어떤 이유로든 에러는 발생할 가능성이 있기 때문에, 이를 반영하는 로직도 추가하는 것이 옳다고 판단했습니다.

## Describe your changes
EvalLogSerach/index.tsx 에 `caclulateTotalCount` 함수 추가,
해당 함수는 query 의 결과를 받아서 number | undefined 를 반환하도록 했습니다.

## Issue number and link
- close #201