### PR TITLE
🐛 fix: 내부에서 로고 클릭 시 /home으로 라우팅

### DIFF
--- a/app/src/@core/components/NavBar/Desktop/index.tsx
+++ b/app/src/@core/components/NavBar/Desktop/index.tsx
@@ -20,7 +20,7 @@ export const DesktopNavBar = ({ fixed = true }: DesktopNavBarProps) => {
   return (
     <Layout fixed={fixed}>
       <VStack w="100%" h="100%" spacing="4rem">
-        <Link to={ROUTES.ROOT} aria-label={ARIA_LABEL_LINK.STAT}>
+        <Link to={ROUTES.HOME} aria-label={ARIA_LABEL_LINK.STAT}>
           <AppLogoTitle size="sm" />
         </Link>
         <DesktopNavProfile


### PR DESCRIPTION
## Summary

## Describe your changes

## Issue number and link
- close #228