### PR TITLE
🐛 fix: 전역 모달을 close 시 unmount

### DIFF
--- a/app/src/@core/components/Modal/ReLoginDialog.tsx
+++ b/app/src/@core/components/Modal/ReLoginDialog.tsx
@@ -1,31 +1,37 @@
+import { isReLoginDialogOpenAtom } from '@core/atoms/isReLoginDialogOpenAtom';
 import { ROUTES } from '@shared/constants/ROUTES';
-import { DialogBaseProps } from '@shared/types/Modal';
 import { AlertDialog } from '@shared/ui-kit';
 import { clearStorage } from '@shared/utils/storage/clearStorage';
+import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-type ReLoginDialogProps = DialogBaseProps;
-
-export const ReLoginDialog = ({ isOpen, onClose }: ReLoginDialogProps) => {
+export const ReLoginDialog = () => {
   const navigate = useNavigate();
+  const [isReLoginDialogOpen, setIsReLoginDialogOpen] = useAtom(
+    isReLoginDialogOpenAtom,
+  );
+
+  const closeReLoginDialog = () => {
+    setIsReLoginDialogOpen(false);
+  };
 
   const handleConfirm = () => {
     clearStorage();
-    onClose();
+    closeReLoginDialog();
     navigate(ROUTES.ROOT);
   };
 
   useEffect(() => {
-    if (!isOpen) {
+    if (!isReLoginDialogOpen) {
       return;
     }
     clearStorage();
-  }, [isOpen]);
+  }, [isReLoginDialogOpen]);
 
   return (
     <AlertDialog
-      isOpen={isOpen}
+      isOpen={isReLoginDialogOpen}
       onClose={() => {
         /* can't close */
       }}

--- a/app/src/@core/components/Modal/ReLoginDialog.tsx
+++ b/app/src/@core/components/Modal/ReLoginDialog.tsx
@@ -31,7 +31,7 @@ export const ReLoginDialog = () => {
 
   return (
     <AlertDialog
-      isOpen={isReLoginDialogOpen}
+      isOpen
       onClose={() => {
         /* can't close */
       }}

--- a/app/src/@core/components/Spotlight/index.tsx
+++ b/app/src/@core/components/Spotlight/index.tsx
@@ -1,12 +1,13 @@
 import { useLazyQuery } from '@apollo/client';
+import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
 import { SpotlightFocusContext } from '@core/contexts/SpotlightFocusContext';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { gql } from '@shared/__generated__';
 import { ReactComponent as MdSearch } from '@shared/assets/icon/md-search.svg';
 import { useRoveFocus } from '@shared/hooks/useRoveFocus';
-import { DialogBaseProps } from '@shared/types/Modal';
 import { Dialog, VStack } from '@shared/ui-kit';
+import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
@@ -26,9 +27,7 @@ export const GET_SEARCH_RESULT = gql(/* GraphQL */ `
   }
 `);
 
-type SpotlightProps = DialogBaseProps;
-
-export const Spotlight = ({ isOpen, onClose }: SpotlightProps) => {
+export const Spotlight = () => {
   const theme = useTheme();
   const [input, setInput] = useState<string>('');
   const debouncedInput = useDebounce(input, 250);
@@ -39,11 +38,24 @@ export const Spotlight = ({ isOpen, onClose }: SpotlightProps) => {
   const { currentFocus, setCurrentFocus } = useRoveFocus(size);
   const LIMIT = 4;
   const location = useLocation();
+  const [isMounted, setIsMounted] = useState(false);
+  const [isSpotlightOpen, setIsSpotlightOpen] = useAtom(isSpotlightOpenAtom);
+
+  const closeSpotlight = () => {
+    setIsSpotlightOpen(false);
+  };
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   // 페이지 이동 감지
   useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
     setInput('');
-    onClose();
+    closeSpotlight();
     setCurrentFocus(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location]);
@@ -73,7 +85,7 @@ export const Spotlight = ({ isOpen, onClose }: SpotlightProps) => {
 
   return (
     <SpotlightFocusContext.Provider value={{ currentFocus, setCurrentFocus }}>
-      <Dialog isOpen={isOpen} onClose={onClose} position="top">
+      <Dialog isOpen={isSpotlightOpen} onClose={closeSpotlight} position="top">
         <Layout>
           <VStack w="100%" h="100%" spacing="2rem">
             <SpotlightSearchBar

--- a/app/src/@core/components/Spotlight/index.tsx
+++ b/app/src/@core/components/Spotlight/index.tsx
@@ -7,7 +7,7 @@ import { gql } from '@shared/__generated__';
 import { ReactComponent as MdSearch } from '@shared/assets/icon/md-search.svg';
 import { useRoveFocus } from '@shared/hooks/useRoveFocus';
 import { Dialog, VStack } from '@shared/ui-kit';
-import { useAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
@@ -39,7 +39,7 @@ export const Spotlight = () => {
   const LIMIT = 4;
   const location = useLocation();
   const [isMounted, setIsMounted] = useState(false);
-  const [isSpotlightOpen, setIsSpotlightOpen] = useAtom(isSpotlightOpenAtom);
+  const setIsSpotlightOpen = useSetAtom(isSpotlightOpenAtom);
 
   const closeSpotlight = () => {
     setIsSpotlightOpen(false);
@@ -85,7 +85,7 @@ export const Spotlight = () => {
 
   return (
     <SpotlightFocusContext.Provider value={{ currentFocus, setCurrentFocus }}>
-      <Dialog isOpen={isSpotlightOpen} onClose={closeSpotlight} position="top">
+      <Dialog isOpen onClose={closeSpotlight} position="top">
         <Layout>
           <VStack w="100%" h="100%" spacing="2rem">
             <SpotlightSearchBar

--- a/app/src/@core/providers/ModalProvider.tsx
+++ b/app/src/@core/providers/ModalProvider.tsx
@@ -3,29 +3,15 @@ import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
 import { ReLoginDialog } from '@core/components/Modal/ReLoginDialog';
 import { Spotlight } from '@core/components/Spotlight';
 import { PropsWithReactElementChildren } from '@shared/types/PropsWithChildren';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 
 const ModalProvider = ({ children }: PropsWithReactElementChildren) => {
-  const [isReLoginDialogOpen, setIsReLoginDialogOpen] = useAtom(
-    isReLoginDialogOpenAtom,
-  );
-  const [isSpotlightOpen, setIsSpotlightOpen] = useAtom(isSpotlightOpenAtom);
-
-  const closeReLoginDialog = () => {
-    setIsReLoginDialogOpen(false);
-  };
-
-  const closeSpotlight = () => {
-    setIsSpotlightOpen(false);
-  };
-
+  const isReLoginDialogOpen = useAtomValue(isReLoginDialogOpenAtom);
+  const isSpotlightOpen = useAtomValue(isSpotlightOpenAtom);
   return (
     <>
-      <ReLoginDialog
-        isOpen={isReLoginDialogOpen}
-        onClose={closeReLoginDialog}
-      />
-      <Spotlight isOpen={isSpotlightOpen} onClose={closeSpotlight} />
+      {isReLoginDialogOpen ? <ReLoginDialog /> : null}
+      {isSpotlightOpen ? <Spotlight /> : null}
       {children}
     </>
   );


### PR DESCRIPTION
## Summary
ModalProvider에서 전역 모달을 관리하는 것은 동일. 

하지만, 전역 모달의 경우 close 되었을 때 unmount가 되어야 함. (아래 ModalProvider.tsx의 변경점 참고)

background에서 계속 keydown을 listening 하고 있는 버그가 있었음. 

## Describe your changes

`Mac + K` 버튼으로 Spotlight를 활성화할 수 있습니다.

하지만 기존 ModalProvider의 방식은 open & close 가 mount & unmount를 불러오지 않습니다. 

전역 모달은 App mount 시에 함께 mount 되며, open & close 는 mount & unmount에 영향을 주지 않았습니다. 

일례로, Spotlight를 끄고 페이지를 움직이지 않은 채 다시 켜면 예전 검색어가 남아있었습니다. 

그것을 나름의 기능이라 생각하고 넘겼었는데, 이번 #199 이슈를 살펴보면서 Spotlight의 ArrowUp, ArrowDown 이 close 상태에도  listening 하고 있는 것이 원인임을 발견하였습니다. 

더하여, Spotlight에서 검색한 이후 Spotlight를 끄고 ArrowUp, ArrowDown을 누르면 Spotlight의 Focus가 움직여버리는 버그가 있다는 사실을 알게 되었습니다. 

따라서 기존 @jpham005 님과 얘기를 나눈 방식대로, close 시 전역 모달을 unmount 시키는 방식으로 로직을 변경하게 되었습니다. 

## Issue number and link
- close #199 