### PR TITLE
🐛 fix: Safari 레벨 증가 그래프 undefined

### DIFF
--- a/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
@@ -129,8 +129,7 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
       theme.colors.accent.default,
     ],
     xaxis: {
-      min: 0,
-      max: 24,
+      type: 'numeric',
       tickAmount: 8,
       labels: {
         formatter: (value) => `${value}개월`,

--- a/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
@@ -116,8 +116,7 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
   const options: ApexCharts.ApexOptions = {
     colors: [theme.colors.primary.default, theme.colors.accent.default],
     xaxis: {
-      min: 0,
-      max: 24,
+      type: 'numeric',
       tickAmount: 8,
       labels: {
         formatter: (value) => `${value}개월`,


### PR DESCRIPTION
## Summary

## Describe your changes

### Safari에서 레벨 증가 그래프 undefined 이슈

min, max 값을 제거하여 해결

### Safari에서 tickAmount를 줄여도 45도 기울어져있는 현상
 - https://github.com/apexcharts/apexcharts.js/issues/1695#issuecomment-661359147
- numeric 타입을 추가하여 해결

ApexCharts는 Safari에 취약합니다... 주의하시길 😭

## Issue number and link
- close #196 