### PR TITLE
🐛 fix: Safari EvalLogSearchDialog width

### DIFF
--- a/app/src/EvalLogSearch/components/EvalLogSearchAbsoluteButton.tsx
+++ b/app/src/EvalLogSearch/components/EvalLogSearchAbsoluteButton.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { ReactComponent as MdSearch } from '@shared/assets/icon/md-search.svg';
 import { ARIA_LABEL_BUTTON } from '@shared/constants/accessibility/ARIA_LABEL';
 import { Clickable } from '@shared/ui-kit';
+import { mq } from '@shared/utils/facepaint/mq';
 
 type EvalLogSearchAbsoluteButtonProps = {
   onClick: () => void;
@@ -33,8 +34,6 @@ export const EvalLogSearchAbsoluteButton = ({
 
 const Layout = styled.div`
   position: fixed;
-  bottom: 10rem;
-  right: 5rem;
   border-radius: ${({ theme }) => theme.radius.circle};
   padding: 1.2rem;
   background-color: ${({ theme }) => theme.colors.primary.default};
@@ -42,6 +41,11 @@ const Layout = styled.div`
   z-index: ${({ theme }) => theme.zIndex.absoluteButton};
   cursor: pointer;
   transition: all 0.2s ease-in-out;
+
+  ${mq({
+    bottom: ['10rem', '5rem'],
+    right: ['3rem', '5rem'],
+  })}
 
   &:hover {
     transform: translateY(-5px);

--- a/app/src/EvalLogSearch/components/EvalLogSearchDialog.tsx
+++ b/app/src/EvalLogSearch/components/EvalLogSearchDialog.tsx
@@ -27,15 +27,19 @@ export const EvalLogSearchDialog = ({
           <ul>
             <li>
               <label htmlFor="projectName">과제명</label>
-              <Input {...register('projectName')} autoFocus />
+              <Input
+                {...register('projectName')}
+                autoFocus
+                style={{ width: '150px' }}
+              />
             </li>
             <li>
               <label htmlFor="corrector">From</label>
-              <Input {...register('corrector')} />
+              <Input {...register('corrector')} style={{ width: '150px' }} />
             </li>
             <li>
               <label htmlFor="corrected">To</label>
-              <Input {...register('corrected')} />
+              <Input {...register('corrected')} style={{ width: '150px' }} />
             </li>
             <li>
               <label htmlFor="flag">플래그</label>


### PR DESCRIPTION
## Summary
<img width="1440" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/96b341d0-f2ad-4ca1-af35-df4d7f337793">

## Describe your changes

## Issue number and link
- close #197