### PR TITLE
🐛 fix: line chart smooth 일 때 animation glitch

### DIFF
--- a/app/src/@shared/components/Chart/LineChart.tsx
+++ b/app/src/@shared/components/Chart/LineChart.tsx
@@ -15,6 +15,11 @@ export const LineChart = ({
   const theme = useTheme();
 
   const lineChartOptions: ApexCharts.ApexOptions = {
+    chart: {
+      animations: {
+        enabled: false, // curve smooth일 때 간헐적으로 curve straight 애니메이션이 적용되는 문제가 있어서 비활성화
+      },
+    },
     colors: [theme.colors.primary.default],
     stroke: {
       curve: 'smooth',

--- a/app/src/@shared/components/DashboardContentView/Number/NumberVersus.tsx
+++ b/app/src/@shared/components/DashboardContentView/Number/NumberVersus.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react';
-import { Avatar, Body1Text, H2MediumText, HStack } from '@shared/ui-kit';
+import { Avatar, H3MediumText, HStack, Text } from '@shared/ui-kit';
 
 type NumberVersusProps = {
   imgUrl1: string | null | undefined;
@@ -23,7 +23,7 @@ export const NumberVersus = ({
       <HStack spacing="1rem">
         <Avatar size="xs" src={imgUrl1} />
         <HStack align="baseline" spacing="0.15rem">
-          <H2MediumText
+          <H3MediumText
             color={
               number1 >= number2
                 ? theme.colors.mono.black
@@ -31,9 +31,9 @@ export const NumberVersus = ({
             }
           >
             {number1.toLocaleString()}
-          </H2MediumText>
+          </H3MediumText>
           {unit ? (
-            <Body1Text
+            <Text
               color={
                 number1 >= number2
                   ? theme.colors.mono.black
@@ -41,14 +41,14 @@ export const NumberVersus = ({
               }
             >
               {unit}
-            </Body1Text>
+            </Text>
           ) : null}
         </HStack>
       </HStack>
       <HStack spacing="1rem">
         <Avatar size="xs" src={imgUrl2} />
         <HStack align="baseline" spacing="0.15rem">
-          <H2MediumText
+          <H3MediumText
             color={
               number1 <= number2
                 ? theme.colors.mono.black
@@ -56,9 +56,9 @@ export const NumberVersus = ({
             }
           >
             {number2.toLocaleString()}
-          </H2MediumText>
+          </H3MediumText>
           {unit ? (
-            <Body1Text
+            <Text
               color={
                 number1 <= number2
                   ? theme.colors.mono.black
@@ -66,7 +66,7 @@ export const NumberVersus = ({
               }
             >
               {unit}
-            </Body1Text>
+            </Text>
           ) : null}
         </HStack>
       </HStack>


### PR DESCRIPTION
## Summary

## Describe your changes

line chart, curve smooth 일 때 발생하는 에러인 것 같고 ApexCharts 이슈에도 올라가있긴 한데, 아직 안 고쳐진 듯함. 

100%로 발생하는 것도 아니라서 애매함. 간헐적으로 발생함. 

현재 할 수 있는 것으로는 line chart curve smooth를 풀거나, 애니메이션을 비활성화하는 방법 둘 중에 하나를 택해야 하는데, 

일단 애니메이션 비활성화를 택함. 

## Issue number and link
- close #239