### PR TITLE
🐛 fix: Layout 밖으로 Link를 뺐을 때 :focus가 적용되지 않음

### DIFF
--- a/app/src/@core/components/NavBar/Desktop/DesktopNavItem.tsx
+++ b/app/src/@core/components/NavBar/Desktop/DesktopNavItem.tsx
@@ -8,6 +8,7 @@ export type NavItemProps = {
   route: NavRoute;
 };
 
+// TODO: Link와 Layout을 합쳐서 StyledLink를 만들고 싶지만, styled(Link)에 isFocused라는 custom prop을 전달할 수 없음.
 export const NavItem = ({ route }: NavItemProps) => {
   const location = useLocation();
   const isFocused = location.pathname.startsWith(route.path);
@@ -17,7 +18,7 @@ export const NavItem = ({ route }: NavItemProps) => {
 
   return (
     <li style={{ width: '100%' }}>
-      <Link to={route.path}>
+      <Link to={route.path} style={{ display: 'block' }}>
         <Layout isFocused={isFocused}>
           <HStack spacing="1.5rem" justify="start">
             <NavItemIcon width={18} height={18} fill={color} />

--- a/app/src/@core/components/NavBar/Tablet/TabletNavItem.tsx
+++ b/app/src/@core/components/NavBar/Tablet/TabletNavItem.tsx
@@ -6,6 +6,7 @@ import type { NavItemProps } from '../Desktop/DesktopNavItem';
 
 type TabletNavItemProps = NavItemProps;
 
+// TODO: Link와 Layout을 합쳐서 StyledLink를 만들고 싶지만, styled(Link)에 isFocused라는 custom prop을 전달할 수 없음.
 export const TabletNavItem = ({ route }: TabletNavItemProps) => {
   const location = useLocation();
   const isFocused = location.pathname.startsWith(route.path);
@@ -17,7 +18,7 @@ export const TabletNavItem = ({ route }: TabletNavItemProps) => {
 
   return (
     <li style={{ width: '100%' }}>
-      <Link to={route.path}>
+      <Link to={route.path} style={{ display: 'block' }}>
         <Layout isFocused={isFocused}>
           <VStack>
             <NavItemIcon width={20} height={20} fill={color} />

--- a/app/src/@shared/ui-kit/Tab/Tab.tsx
+++ b/app/src/@shared/ui-kit/Tab/Tab.tsx
@@ -17,20 +17,19 @@ export const Tab = ({ selected = false, link, children }: TabProps) => {
 
   return (
     <li>
-      <Link to={link}>
-        <Layout selected={selected} tabIndex={0}>
-          <Text color={color}>{children}</Text>
-        </Layout>
-      </Link>
+      <StyledLink selected={selected} to={link}>
+        <Text color={color}>{children}</Text>
+      </StyledLink>
     </li>
   );
 };
 
-type LayoutProps = {
+type StyledLinkProps = {
   selected: boolean;
 };
 
-const Layout = styled.div<LayoutProps>`
+const StyledLink = styled(Link)<StyledLinkProps>`
+  display: block;
   padding: 1.4rem 2rem;
   transition: background-color 0.3s;
   outline-offset: -0.2rem;

--- a/app/src/Leaderboard/components/Leaderboard/LeaderboardListItem.tsx
+++ b/app/src/Leaderboard/components/Leaderboard/LeaderboardListItem.tsx
@@ -25,6 +25,7 @@ type LeaderboardListItemProps = {
   fixedNumber?: number;
 };
 
+// TODO: Link와 Layout을 합쳐서 StyledLink를 만들고 싶지만, styled(Link)에 isMe라는 custom prop을 전달할 수 없음.
 export const LeaderboardListItem = ({
   item,
   unit,
@@ -41,8 +42,8 @@ export const LeaderboardListItem = ({
 
   return (
     <li style={{ width: '100%' }}>
-      <Link to={ROUTES.PROFILE_OF(login)}>
-        <Layout isMe={isMe} tabIndex={0}>
+      <Link to={ROUTES.PROFILE_OF(login)} style={{ display: 'block' }}>
+        <Layout isMe={isMe}>
           <TabletAndAbove>
             <HStack w="100%" spacing="4rem">
               <HStack w="5rem">
@@ -100,7 +101,7 @@ const Layout = styled.div<LayoutProps>`
   background-color: ${({ isMe, theme }) =>
     isMe && theme.colors.primary.default} !important; // FIXME: !important
   user-select: ${({ isMe }) => isMe && 'none'};
-  transition: all 0.2s;
+  transition: background-color 0.2s;
 
   &:hover {
     background-color: ${({ theme, isMe }) =>


### PR DESCRIPTION
## Summary

## Describe your changes

아래 이슈에 더하여, navigate -> link 사용으로 바뀌었지만 내부 layout에 tabIndex가 여전히 설정되어 있어 tab키로 움직일 때에는 동일 요소를 두번 focus 하는 버그가 있어서 tabIndex를 삭제하였습니다. 

## Issue number and link
- close #251