### PR TITLE
:bug: fix: GET_RECENT_TEAM_RESULT query 에 불필요한 인자를 제공하던 문제 수정

### DIFF
--- a/app/src/Home/dashboard-contents/Team/RecentExamResult.tsx
+++ b/app/src/Home/dashboard-contents/Team/RecentExamResult.tsx
@@ -34,9 +34,7 @@ const GET_RECENT_EXAM_RESULT = gql(/* GraphQL */ `
 
 export const RecentExamResult = () => {
   const title = '직전 회차 시험 통과율';
-  const { loading, error, data } = useQuery(GET_RECENT_EXAM_RESULT, {
-    variables: { after: 1 },
-  });
+  const { loading, error, data } = useQuery(GET_RECENT_EXAM_RESULT);
 
   if (loading) {
     return <DashboardContentLoading title={title} />;


### PR DESCRIPTION
## Summary
GET_RECENT_EXAM_RESULT query 를 기존에 variables 를 제공하지 않고 있었는데,
257b0cd 에서 variables 를 추가하면서 마지막에서 두번째 시험이 반환되는 문제가 있었습니다.
이를 제거하여 다시 가장 최근 시험 결과를 반환 받고자 합니다.

## Describe your change
모호한 variable key 이름으로 인해 생긴 문제라고 봅니다.
이후 백엔드에서 이름을 수정할 예정 입니다.

## Issue number and link
