### PR TITLE
fix(design): 팀 페이지 평가기록 짧을 때도 채워지도록 수정

### DIFF
--- a/app/src/Team/index.tsx
+++ b/app/src/Team/index.tsx
@@ -165,12 +165,12 @@ const TeamPage = () => {
           </CustomLink>
         </VStack>
         <Divider />
-        <VStack align="start" spacing="3rem">
+        <VStack w="100%" align="start" spacing="3rem">
           <H2BoldText>평가 기록</H2BoldText>
           {moulinette == null && evalLogs.length === 0 ? (
             <Text>평가 기록이 없습니다.</Text>
           ) : null}
-          <VStack align="start" spacing="1.5rem">
+          <VStack w="100%" align="start" spacing="1.5rem">
             <EvalLogList list={evalLogs} />
             {moulinette != null ? (
               <MoulinetteEvalLogListItem item={moulinette} />


### PR DESCRIPTION
## Summary
<img width="1175" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/41469692-95e9-4ebf-8b76-eb4bd9a96d11">

## Describe your changes

## Issue number and link
- close #268 