### PR TITLE
fix(Chart): 레벨 증가 그래프 모든 legend 껐을 때 x축 수치 달라짐

### DIFF
--- a/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/General/LevelRecords.tsx
@@ -130,6 +130,8 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
     ],
     xaxis: {
       type: 'numeric',
+      min: 0,
+      max: 24,
       tickAmount: 8,
       labels: {
         formatter: (value) => `${value}개월`,

--- a/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/LevelRecords.tsx
@@ -120,6 +120,8 @@ const LevelRecordsChart = ({ series }: LevelRecordsChartProps) => {
     ],
     xaxis: {
       type: 'numeric',
+      min: 0,
+      max: 24,
       tickAmount: 8,
       labels: {
         formatter: (value) => `${value}개월`,


### PR DESCRIPTION
## Summary
<img width="1102" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/8ffc5764-87d8-433e-a52c-73b042370c7a">

## Describe your changes

## Issue number and link
- close #286 