### PR TITLE
fix(versus): 본과정 시작 전 유저에 대한 "본과정 시작한지" 카드 오류

### DIFF
--- a/app/src/Profile/dashboard-contents/Versus/DayFromBeginAt.tsx
+++ b/app/src/Profile/dashboard-contents/Versus/DayFromBeginAt.tsx
@@ -36,8 +36,8 @@ export const DayFromBeginAt = () => {
     data2: { beginAt },
   } = data;
 
-  const diff = Math.abs(getTimeDiffFromNow(new Date(beginAt), 'day'));
-  const myDiff = Math.abs(getTimeDiffFromNow(new Date(myBeginAt), 'day'));
+  const diff = -getTimeDiffFromNow(new Date(beginAt), 'day');
+  const myDiff = -getTimeDiffFromNow(new Date(myBeginAt), 'day');
   const unit = '일째';
 
   return (


### PR DESCRIPTION
## Summary

<img width="390" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/d8389cfe-a01e-4282-8d40-5592e6a0d000">

## Describe your changes

음수로 표현하는 것은 UI 상 좋지 않아보이지만, 마땅히 생각나는 대체 문구가 없어서 일단 두었습니다.  
추후 develop 브랜치에서 **아직 들어오지 않은 신규 유저에 대한 고려**를 별도 이슈로 올리겠습니다. 

## Issue number and link
- fix #294 