### PR TITLE
[Feat] FAB 추가

### DIFF
--- a/app/src/@shared/ui-kit/Clickable/Clickable.tsx
+++ b/app/src/@shared/ui-kit/Clickable/Clickable.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import type { PropsWithReactNodeChildren } from '@shared/types/PropsWithChildren';
 
-type ClickableProps = PropsWithReactNodeChildren<
+export type ClickableProps = PropsWithReactNodeChildren<
   React.ButtonHTMLAttributes<HTMLButtonElement>
 > & {
   forwardRef?: React.Ref<HTMLButtonElement>;

--- a/app/src/@shared/ui-kit/FAB/FAB.tsx
+++ b/app/src/@shared/ui-kit/FAB/FAB.tsx
@@ -1,0 +1,63 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {
+  Clickable,
+  HStack,
+  WhiteBody1MediumText,
+  type ClickableProps,
+} from '@shared/ui-kit';
+
+// text를 넣으면 Extended FAB가 됩니다.
+export type FABProps = Omit<ClickableProps, 'children'> & {
+  icon: React.ReactElement;
+  backgroundColor?: string;
+  text?: string;
+};
+
+export const FAB = ({
+  icon,
+  backgroundColor,
+  text,
+  ...clickableProps
+}: FABProps) => {
+  const theme = useTheme();
+
+  backgroundColor = backgroundColor ?? theme.colors.primary.default;
+
+  return (
+    <Clickable {...clickableProps}>
+      <Layout backgroundColor={backgroundColor}>
+        {text ? (
+          <HStack spacing="1rem">
+            {icon}
+            <WhiteBody1MediumText>{text}</WhiteBody1MediumText>
+          </HStack>
+        ) : (
+          icon
+        )}
+      </Layout>
+    </Clickable>
+  );
+};
+
+type LayoutProps = {
+  backgroundColor?: string;
+};
+
+const Layout = styled.div<LayoutProps>`
+  border-radius: ${({ theme }) => theme.radius.md};
+  padding: 1.8rem;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  z-index: ${({ theme }) => theme.zIndex.absoluteButton};
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    transform: translateY(-5px);
+  }
+
+  &:focus {
+    outline: 2px solid blue;
+  }
+`;

--- a/app/src/@shared/ui-kit/FAB/index.tsx
+++ b/app/src/@shared/ui-kit/FAB/index.tsx
@@ -1,0 +1,1 @@
+export * from './FAB';

--- a/app/src/EvalLogSearch/components/EvalLogSearchAbsoluteButton.tsx
+++ b/app/src/EvalLogSearch/components/EvalLogSearchAbsoluteButton.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ReactComponent as MdSearch } from '@shared/assets/icon/md-search.svg';
 import { ARIA_LABEL } from '@shared/constants/accessibility';
-import { Clickable } from '@shared/ui-kit';
+import { FAB } from '@shared/ui-kit/FAB';
 import { mq } from '@shared/utils/facepaint/mq';
 
 type EvalLogSearchAbsoluteButtonProps = {
@@ -15,40 +15,24 @@ export const EvalLogSearchAbsoluteButton = ({
   const theme = useTheme();
 
   return (
-    <>
-      <Clickable
+    <Layout>
+      <FAB
+        icon={
+          <MdSearch width={30} height={30} fill={theme.colors.mono.white} />
+        }
         onClick={onClick}
         tabIndex={1}
         aria-label={ARIA_LABEL.BUTTON.SEARCH_EVAL_LOGS}
-      >
-        <Layout>
-          <MdSearch width={26} height={26} fill={theme.colors.mono.white} />
-        </Layout>
-      </Clickable>
-    </>
+      />
+    </Layout>
   );
 };
 
 const Layout = styled.div`
   position: fixed;
-  border-radius: ${({ theme }) => theme.radius.circle};
-  padding: 1.2rem;
-  background-color: ${({ theme }) => theme.colors.primary.default};
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  z-index: ${({ theme }) => theme.zIndex.absoluteButton};
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
 
   ${mq({
     bottom: ['10rem', '5rem'],
     right: ['3rem', '5rem'],
   })}
-
-  &:hover {
-    transform: translateY(-5px);
-  }
-
-  &:focus {
-    outline: 2px solid blue;
-  }
 `;


### PR DESCRIPTION
## Summary

- FAB를 추가하였습니다. 
- 평가로그 검색 버튼이 더 눈에 띄게 변경되었습니다. 

Ref. <https://mui.com/material-ui/react-floating-action-button/>

## Describe your changes

기존

<img width="110" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/c5777569-59ae-4f9b-abae-eb3b43121800">

변경

<img width="150" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/40faa08b-04d3-45f5-b1a4-7e6d88a52724">

Extended FAB (예시)
<img width="227" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/8c6b9b90-793d-4899-a1ee-325e153843e8">


## Issue number and link
- close #331 