### PR TITLE
[Fix] ReLoginDialog body 텍스트 고정

### DIFF
--- a/app/src/@core/providers/ApolloProvider.tsx
+++ b/app/src/@core/providers/ApolloProvider.tsx
@@ -157,7 +157,11 @@ const ResponseInterceptor400 = ({
               }
               setReLoginDialogInfo({
                 isOpen: true,
-                description: error.message,
+                /**
+                 * 현재 BE에서 400 상태코드를 Code로 구분해주지 않기 때문에, description이 항상 고정입니다.
+                 * 이후 BE에서 Code로 구분해주면, Code에 따라 상응하는 description(= ReLoginDialog body) 분기할 예정입니다.
+                 */
+                description: '다시 로그인해주세요.',
               });
               break;
           }


### PR DESCRIPTION
## Summary

<img width="679" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/6a439dd8-4f64-46a6-9c71-eef10bc2d2aa">

## Describe your changes

- 기존 안에서는 `error.message`가 그대로 노출되어 UX 상 좋지 않다는 피드백이 있었습니다. 
- 이후 Backend 400 반환 시 Code가 분기되면, 그에 상응하는 body text를 다시 변경할 예정입니다. 

## Issue number and link
- close #330 