### PR TITLE
[Fix] 데이터가 없을 때에 대한 핸들링 (최근 쓴 코멘트, 인연 스코어)

### DIFF
--- a/app/src/Profile/dashboard-contents/Eval/DestinyRanking.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/DestinyRanking.tsx
@@ -58,7 +58,7 @@ export const DestinyRanking = () => {
       {destinyRanking.length !== 0 ? (
         <UserRankList list={destinyRanking} cnt={5} unit={unit} />
       ) : (
-        <TextDefault text="인연 기록이 없습니다" />
+        <TextDefault text="인연 기록이 없어요" />
       )}
     </DashboardContent>
   );

--- a/app/src/Profile/dashboard-contents/Eval/DestinyRanking.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/DestinyRanking.tsx
@@ -8,6 +8,7 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { UserRankList } from '@shared/components/DashboardContentView/Rank/UserRankList';
+import { TextDefault } from '@shared/components/DashboardContentView/Text/TextDefault';
 import { useContext } from 'react';
 
 const GET_DESTINY_RANKING_BY_LOGIN = gql(/* GraphQL */ `
@@ -54,7 +55,11 @@ export const DestinyRanking = () => {
 
   return (
     <DashboardContent title={title} description={description}>
-      <UserRankList list={destinyRanking} cnt={5} unit={unit} />
+      {destinyRanking.length !== 0 ? (
+        <UserRankList list={destinyRanking} cnt={5} unit={unit} />
+      ) : (
+        <TextDefault text="인연 기록이 없습니다" />
+      )}
     </DashboardContent>
   );
 };

--- a/app/src/Profile/dashboard-contents/Eval/RecentComment.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/RecentComment.tsx
@@ -6,6 +6,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { TextDefault } from '@shared/components/DashboardContentView/Text/TextDefault';
 import { InfoTooltip } from '@shared/components/InfoTooltip';
 import { Text } from '@shared/ui-kit';
 import { useContext } from 'react';
@@ -35,12 +36,23 @@ export const RecentComment = () => {
   const { recentComment } = data.getPersonalEval; // FIXME: null일 수 있음.
 
   return (
-    <DashboardContent
-      title={title}
-      titleRight={<InfoTooltip text="코멘트 : 평가하러 가서 작성한 리뷰" />}
-      type="Scrollable"
-    >
-      <Text>{recentComment}</Text>
-    </DashboardContent>
+    <>
+      {recentComment ? (
+        <DashboardContent
+          title={title}
+          titleRight={<InfoTooltip text="코멘트 : 평가하러 가서 작성한 리뷰" />}
+          type="Scrollable"
+        >
+          <Text>{recentComment}</Text>
+        </DashboardContent>
+      ) : (
+        <DashboardContent
+          title={title}
+          titleRight={<InfoTooltip text="코멘트 : 평가하러 가서 작성한 리뷰" />}
+        >
+          <TextDefault text="평가 기록이 없습니다" />
+        </DashboardContent>
+      )}
+    </>
   );
 };

--- a/app/src/Profile/dashboard-contents/Eval/RecentComment.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/RecentComment.tsx
@@ -50,7 +50,7 @@ export const RecentComment = () => {
           title={title}
           titleRight={<InfoTooltip text="코멘트 : 평가하러 가서 작성한 리뷰" />}
         >
-          <TextDefault text="평가 기록이 없습니다" />
+          <TextDefault text="평가 기록이 없어요" />
         </DashboardContent>
       )}
     </>

--- a/app/src/Profile/dashboard-contents/General/TeamInfo/index.tsx
+++ b/app/src/Profile/dashboard-contents/General/TeamInfo/index.tsx
@@ -2,11 +2,13 @@ import { UserProfileContext } from '@/Profile/contexts/UserProfileContext';
 import { useQuery } from '@apollo/client';
 import styled from '@emotion/styled';
 import { gql } from '@shared/__generated__';
+import { DashboardContent } from '@shared/components/DashboardContent';
 import {
   DashboardContentBadRequest,
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { TextDefault } from '@shared/components/DashboardContentView/Text/TextDefault';
 import { useContext } from 'react';
 import { TeamInfoTable } from './TeamInfoTable';
 
@@ -41,19 +43,29 @@ export const TeamInfo = () => {
 
   const { teams } = data.getPersonalGeneral.teamInfo;
 
+  const title = '팀 정보';
+
   return (
-    <TeamInfoLayout>
-      <div
-        style={{
-          position: 'relative',
-          width: '100%',
-          height: '100%',
-          overflow: 'auto',
-        }}
-      >
-        <TeamInfoTable teams={teams} />
-      </div>
-    </TeamInfoLayout>
+    <>
+      {teams.length === 0 ? (
+        <TeamInfoLayout>
+          <div
+            style={{
+              position: 'relative',
+              width: '100%',
+              height: '100%',
+              overflow: 'auto',
+            }}
+          >
+            <TeamInfoTable teams={teams} />
+          </div>
+        </TeamInfoLayout>
+      ) : (
+        <DashboardContent title={title}>
+          <TextDefault text="프로젝트 신청 기록이 없습니다." />
+        </DashboardContent>
+      )}
+    </>
   );
 };
 

--- a/app/src/Profile/dashboard-contents/General/TeamInfo/index.tsx
+++ b/app/src/Profile/dashboard-contents/General/TeamInfo/index.tsx
@@ -62,7 +62,7 @@ export const TeamInfo = () => {
         </TeamInfoLayout>
       ) : (
         <DashboardContent title={title}>
-          <TextDefault text="프로젝트 신청 기록이 없습니다." />
+          <TextDefault text="프로젝트 신청 기록이 없어요" />
         </DashboardContent>
       )}
     </>

--- a/app/src/Project/dashboard-contents/ValidatedRate.tsx
+++ b/app/src/Project/dashboard-contents/ValidatedRate.tsx
@@ -55,7 +55,7 @@ export const ValidatedRate = () => {
   if (validatedRate.total === 0) {
     return (
       <DashboardContent title={title}>
-        <H3Text>제출 기록이 없어요 😐</H3Text>
+        <H3Text>제출 기록이 없어요</H3Text>
       </DashboardContent>
     );
   }

--- a/app/src/Team/index.tsx
+++ b/app/src/Team/index.tsx
@@ -169,7 +169,7 @@ const TeamPage = () => {
         <VStack w="100%" align="start" spacing="3rem">
           <H2BoldText>평가 기록</H2BoldText>
           {moulinette == null && evalLogs.length === 0 ? (
-            <Text>평가 기록이 없습니다.</Text>
+            <Text>평가 기록이 없어요</Text>
           ) : null}
           <VStack w="100%" align="start" spacing="1.5rem">
             <EvalLogList list={evalLogs} />


### PR DESCRIPTION
## Summary

최근 쓴 코멘트 없을 때
<img width="394" alt="스크린샷 2023-10-18 오후 8 48 15" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/3788f3e9-ac9e-4b0e-8c47-f2b2b8e775ca">

인연 스코어 없을 때
<img width="386" alt="스크린샷 2023-10-18 오후 8 50 51" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/95ded19c-8d56-4dc8-a5e6-17e38cd230d6">

## Describe your changes

TeamInfo 표는 적절한 UI가 잘 생각이 나지 않아 일단 보류합니다. 

## Issue number and link
- close #329