### PR TITLE
[Hotfix] 코멘트 길이 랭킹 handlePageNumberChange 보완

### DIFF
--- a/app/src/Leaderboard/pages/Comment/components/LeaderboardCommentResult.tsx
+++ b/app/src/Leaderboard/pages/Comment/components/LeaderboardCommentResult.tsx
@@ -33,12 +33,13 @@ export function LeaderboardCommentResult({
   result: { loading, error, data },
 }: LeaderboardCommentResultProps) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { promo, pageNumber } = toLeaderboardArgs(searchParams);
-  const { PROMO, PAGE } = LEADERBOARD_PARAM_KEYS;
+  const { promo, dateTemplate, pageNumber } = toLeaderboardArgs(searchParams);
+  const { PROMO, DATE, PAGE } = LEADERBOARD_PARAM_KEYS;
 
   function handlePageNumberChange(newPageNumber: number) {
     const newURLSearchParams = new URLSearchParams();
 
+    newURLSearchParams.set(DATE, dateTemplate);
     if (promo) {
       newURLSearchParams.set(PROMO, promo.toString());
     }


### PR DESCRIPTION
기존 dateTemplate이 없다가 새로 추가하면서 이걸 빼먹었네요...

## Summary

## Describe your changes

### 버그 재현 방법

코멘트 길이 랭킹 [누적] 선택 후 페이지 변경하면, [주간] (기본 default 값)의 해당 페이지로 잘못 이동합니다. 

## Issue number and link
