### PR TITLE
[Fix] Firefox에서 td overflow-x 적용 안됨

### DIFF
--- a/app/src/Profile/dashboard-contents/General/TeamInfo/TeamInfoTable.tsx
+++ b/app/src/Profile/dashboard-contents/General/TeamInfo/TeamInfoTable.tsx
@@ -88,7 +88,7 @@ const Table = styled.table`
 
   td {
     max-width: 300px;
-    overflow-x: hidden;
+    overflow: hidden;
     text-align: center;
     padding: 0.4rem 2rem;
     vertical-align: middle;


### PR DESCRIPTION
## Summary

In Firefox,

jkong
<img width="1145" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/24098992-de4e-4fc9-9c16-ba5366c22a60">

jiychoi
<img width="1141" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/1c6542fa-fbb8-4e09-9570-a4decea69338">


## Describe your changes

- firefox에서 td overflow-x 적용 안되는 문제가 있는데, 이유를 못 찾았습니다. 
- `overflow-x: hidden`을 `overflow: hidden`으로 변경하는 방식으로 해결하였습니다. 
- Chrome, Safari에서는 되는데 말이죠...😭

## Issue number and link
- close #295
- 둘러본 결과 Firefox에서 깨지는 UI가 해당 이슈 제외하고 없는 듯합니다. Project에 있는 **Firefox UI 테스트** 카드를 해당 이슈 종료와 함께 Done으로 옮기고, 앞으로는 Firefox 최신 버전도 Chrome, Safari와 함께 테스트하기로 하였습니다. 