### PR TITLE
[Fix] spotlight & reloginDialog error

### DIFF
--- a/app/src/@core/components/Modal/ReLoginDialog.tsx
+++ b/app/src/@core/components/Modal/ReLoginDialog.tsx
@@ -1,14 +1,11 @@
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { reLoginDialogInfoAtom } from '@core/atoms/reLoginDialogInfoAtom';
-import { ROUTES } from '@shared/constants/routes';
 import { AlertDialog } from '@shared/ui-kit';
 import { clearStorage } from '@shared/utils/storage/clearStorage';
 
 export const ReLoginDialog = () => {
-  const navigate = useNavigate();
   const [{ isOpen, description }, setReLoginDialogInfo] = useAtom(
     reLoginDialogInfoAtom,
   );
@@ -23,7 +20,7 @@ export const ReLoginDialog = () => {
   const handleConfirm = () => {
     clearStorage();
     closeReLoginDialog();
-    navigate(ROUTES.ROOT);
+    window.location.reload();
   };
 
   useEffect(() => {

--- a/app/src/@core/components/Spotlight/index.tsx
+++ b/app/src/@core/components/Spotlight/index.tsx
@@ -3,7 +3,6 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
 
 import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
@@ -31,10 +30,8 @@ export const GET_SPOTLIGHT = gql(/* GraphQL */ `
 
 export const Spotlight = () => {
   const theme = useTheme();
-  const location = useLocation();
   const device = useDeviceType();
   const LIMIT = 4;
-  const [isMounted, setIsMounted] = useState(false);
   const [input, setInput] = useState<string>('');
   const debouncedInput = useDebounce(input, 50);
   const [search, searchResult] = useLazyQuery(GET_SPOTLIGHT);
@@ -51,21 +48,6 @@ export const Spotlight = () => {
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setInput(e.target.value);
   };
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // 페이지 이동 감지
-  useEffect(() => {
-    if (!isMounted) {
-      return;
-    }
-    setInput('');
-    closeSpotlight();
-    setCurrentFocus(0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location]);
 
   useEffect(() => {
     setCurrentFocus(0);


### PR DESCRIPTION
## Summary
근본적인 해결책을 못찾았습니다.
임시로 spotlight, relogindialog 에러를 고쳤어요

## Describe your changes
- spotlight에서 페이지 이동시 spotlight이 꺼지는 로직을 뺐습니다 -> 언제 쓰이는지 모르겠네요
- reloginDialog에서 navigate 대신 페이지 새로고침을 시켰습니다 -> 이거는 logout쪽도 이런식으로 바꾸려고 생각중이에요 (atom상태 유지되는 현상 때문)
<br />
<br />


이것저것 찾아본 결과 Provider 바깥에 Router로 감싸져 있어야 하는 것 같아요
근데 `<RouterProvider router={router} />` 형태로 만드셔서
바꾸려면 꽤나 작업이 커질 것 같아 임시 작업만 한 상태입니다
나중에 provider에서 useLocation 또는 navigate를 사용하게 되면 고치긴 해야되는 문제로 보입니다 😢
Ref. [참고사이트](https://stackoverflow.com/questions/66747556/react-js-error-uselocation-may-be-used-only-in-the-context-of-a-router-com)

## Issue number and link
- close #350 
