### PR TITLE
[Fix] ModalProvider를 router 내부로 이동

### DIFF
--- a/app/src/@core/AppProvider.tsx
+++ b/app/src/@core/AppProvider.tsx
@@ -1,7 +1,6 @@
 import ApolloProvider from '@core/providers/ApolloProvider';
 import ErrorBoundaryProvider from '@core/providers/ErrorBoundaryProvider';
 import HelmetProvider from '@core/providers/HelmetProvider';
-import ModalProvider from '@core/providers/ModalProvider';
 import ThemeProvider from '@core/providers/ThemeProvider';
 import type { PropsWithReactElementChildren } from '@shared/types/PropsWithChildren';
 
@@ -10,9 +9,7 @@ export const AppProvider = ({ children }: PropsWithReactElementChildren) => {
     <ErrorBoundaryProvider>
       <ApolloProvider>
         <HelmetProvider>
-          <ThemeProvider>
-            <ModalProvider>{children}</ModalProvider>
-          </ThemeProvider>
+          <ThemeProvider>{children}</ThemeProvider>
         </HelmetProvider>
       </ApolloProvider>
     </ErrorBoundaryProvider>

--- a/app/src/@core/appRouter.tsx
+++ b/app/src/@core/appRouter.tsx
@@ -9,6 +9,7 @@ import { ProfileVersusPageSkeleton } from '@/Profile/components/skeletons/Profil
 import { UserProfileSkeleton } from '@/Profile/components/skeletons/UserProfileSkeleton';
 import { AuthGuard } from '@core/guards/AuthGuard';
 import { UnAuthGuard } from '@core/guards/UnAuthGuard';
+import { ModalProvider } from '@core/providers/ModalProvider';
 import { ROUTES } from '@shared/constants/routes';
 import { DeferredComponent } from '@shared/ui-kit';
 
@@ -43,213 +44,218 @@ const CalculatorPage = lazy(() => import('@/Calculator'));
 
 export const appRouter = createBrowserRouter([
   {
-    element: <UnAuthGuard />,
+    element: <ModalProvider />,
     children: [
       {
-        element: (
-          <Suspense>
-            <LandingLayout />
-          </Suspense>
-        ),
+        element: <UnAuthGuard />,
         children: [
           {
-            path: ROUTES.ROOT,
             element: (
               <Suspense>
-                <LandingPage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.FT_OAUTH_REQUEST,
-            element: (
-              <Suspense>
-                <FtOAuthRequestPage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.FT_OAUTH_REDIRECT,
-            element: (
-              <Suspense>
-                <FtOAuthRedirectPage />
-              </Suspense>
-            ),
-          },
-        ],
-      },
-    ],
-  },
-  {
-    element: <AuthGuard />,
-    children: [
-      {
-        element: (
-          <Suspense>
-            <MainLayout />
-          </Suspense>
-        ),
-        children: [
-          {
-            path: ROUTES.HOME,
-            element: (
-              <Suspense
-                fallback={
-                  <DeferredComponent>
-                    <HomePageSkeleton />
-                  </DeferredComponent>
-                }
-              >
-                <HomePage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.PROFILE,
-            element: (
-              <Suspense fallback={<UserProfileSkeleton />}>
-                <ProfileLayout />
+                <LandingLayout />
               </Suspense>
             ),
             children: [
               {
-                index: true,
-                element: <Navigate replace to="general" />,
-              },
-              {
-                path: ROUTES.PROFILE_GENERAL,
+                path: ROUTES.ROOT,
                 element: (
-                  <Suspense fallback={<ProfileGeneralPageSkeleton />}>
-                    <ProfileGeneralPage />
+                  <Suspense>
+                    <LandingPage />
                   </Suspense>
                 ),
               },
               {
-                path: ROUTES.PROFILE_EVAL,
+                path: ROUTES.FT_OAUTH_REQUEST,
                 element: (
-                  <Suspense fallback={<ProfileEvalPageSkeleton />}>
-                    <ProfileEvalPage />
+                  <Suspense>
+                    <FtOAuthRequestPage />
                   </Suspense>
                 ),
               },
               {
-                path: ROUTES.PROFILE_VERSUS,
+                path: ROUTES.FT_OAUTH_REDIRECT,
                 element: (
-                  <Suspense fallback={<ProfileVersusPageSkeleton />}>
-                    <ProfileVersusPage />
+                  <Suspense>
+                    <FtOAuthRedirectPage />
                   </Suspense>
                 ),
               },
             ],
           },
+        ],
+      },
+      {
+        element: <AuthGuard />,
+        children: [
           {
-            path: ROUTES.LEADERBOARD,
             element: (
               <Suspense>
-                <LeaderboardLayout />
+                <MainLayout />
               </Suspense>
             ),
             children: [
               {
-                index: true,
-                element: <Navigate replace to="level" />,
-              },
-              {
-                path: ROUTES.LEADERBOARD_LEVEL,
+                path: ROUTES.HOME,
                 element: (
-                  <Suspense fallback={<LeaderboardPageSkeleton />}>
-                    <LeaderboardLevelPage />
+                  <Suspense
+                    fallback={
+                      <DeferredComponent>
+                        <HomePageSkeleton />
+                      </DeferredComponent>
+                    }
+                  >
+                    <HomePage />
                   </Suspense>
                 ),
               },
               {
-                path: ROUTES.LEADERBOARD_EXP_INCREMENT,
+                path: ROUTES.PROFILE,
                 element: (
-                  <Suspense fallback={<LeaderboardPageSkeleton />}>
-                    <LeaderboardExpIncrementPage />
+                  <Suspense fallback={<UserProfileSkeleton />}>
+                    <ProfileLayout />
+                  </Suspense>
+                ),
+                children: [
+                  {
+                    index: true,
+                    element: <Navigate replace to="general" />,
+                  },
+                  {
+                    path: ROUTES.PROFILE_GENERAL,
+                    element: (
+                      <Suspense fallback={<ProfileGeneralPageSkeleton />}>
+                        <ProfileGeneralPage />
+                      </Suspense>
+                    ),
+                  },
+                  {
+                    path: ROUTES.PROFILE_EVAL,
+                    element: (
+                      <Suspense fallback={<ProfileEvalPageSkeleton />}>
+                        <ProfileEvalPage />
+                      </Suspense>
+                    ),
+                  },
+                  {
+                    path: ROUTES.PROFILE_VERSUS,
+                    element: (
+                      <Suspense fallback={<ProfileVersusPageSkeleton />}>
+                        <ProfileVersusPage />
+                      </Suspense>
+                    ),
+                  },
+                ],
+              },
+              {
+                path: ROUTES.LEADERBOARD,
+                element: (
+                  <Suspense>
+                    <LeaderboardLayout />
+                  </Suspense>
+                ),
+                children: [
+                  {
+                    index: true,
+                    element: <Navigate replace to="level" />,
+                  },
+                  {
+                    path: ROUTES.LEADERBOARD_LEVEL,
+                    element: (
+                      <Suspense fallback={<LeaderboardPageSkeleton />}>
+                        <LeaderboardLevelPage />
+                      </Suspense>
+                    ),
+                  },
+                  {
+                    path: ROUTES.LEADERBOARD_EXP_INCREMENT,
+                    element: (
+                      <Suspense fallback={<LeaderboardPageSkeleton />}>
+                        <LeaderboardExpIncrementPage />
+                      </Suspense>
+                    ),
+                  },
+                  {
+                    path: ROUTES.LEADERBOARD_SCORE,
+                    element: (
+                      <Suspense fallback={<LeaderboardPageSkeleton />}>
+                        <LeaderboardScorePage />
+                      </Suspense>
+                    ),
+                  },
+                  {
+                    path: ROUTES.LEADERBOARD_EVAL_COUNT,
+                    element: (
+                      <Suspense fallback={<LeaderboardPageSkeleton />}>
+                        <LeaderboardEvalCountPage />
+                      </Suspense>
+                    ),
+                  },
+                  {
+                    path: ROUTES.LEADERBOARD_COMMENT,
+                    element: (
+                      <Suspense fallback={<LeaderboardPageSkeleton />}>
+                        <LeaderboardCommentPage />
+                      </Suspense>
+                    ),
+                  },
+                ],
+              },
+              {
+                path: ROUTES.TEAM,
+                element: (
+                  <Suspense>
+                    <TeamPage />
                   </Suspense>
                 ),
               },
               {
-                path: ROUTES.LEADERBOARD_SCORE,
+                path: ROUTES.EVALLOG,
                 element: (
-                  <Suspense fallback={<LeaderboardPageSkeleton />}>
-                    <LeaderboardScorePage />
+                  <Suspense>
+                    <EvalLogSearchPage />
                   </Suspense>
                 ),
               },
               {
-                path: ROUTES.LEADERBOARD_EVAL_COUNT,
+                path: ROUTES.PROJECT_DETAIL,
                 element: (
-                  <Suspense fallback={<LeaderboardPageSkeleton />}>
-                    <LeaderboardEvalCountPage />
+                  <Suspense>
+                    <ProjectDetailPage />
                   </Suspense>
                 ),
               },
               {
-                path: ROUTES.LEADERBOARD_COMMENT,
+                path: ROUTES.CALCULATOR,
                 element: (
-                  <Suspense fallback={<LeaderboardPageSkeleton />}>
-                    <LeaderboardCommentPage />
+                  <Suspense>
+                    <CalculatorPage />
+                  </Suspense>
+                ),
+              },
+              {
+                path: ROUTES.SETTING,
+                element: (
+                  <Suspense>
+                    <SettingPage />
                   </Suspense>
                 ),
               },
             ],
           },
+        ],
+      },
+      {
+        element: <LandingLayout />,
+        children: [
           {
-            path: ROUTES.TEAM,
+            path: '*',
             element: (
               <Suspense>
-                <TeamPage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.EVALLOG,
-            element: (
-              <Suspense>
-                <EvalLogSearchPage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.PROJECT_DETAIL,
-            element: (
-              <Suspense>
-                <ProjectDetailPage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.CALCULATOR,
-            element: (
-              <Suspense>
-                <CalculatorPage />
-              </Suspense>
-            ),
-          },
-          {
-            path: ROUTES.SETTING,
-            element: (
-              <Suspense>
-                <SettingPage />
+                <NotFoundPage />
               </Suspense>
             ),
           },
         ],
-      },
-    ],
-  },
-  {
-    element: <LandingLayout />,
-    children: [
-      {
-        path: '*',
-        element: (
-          <Suspense>
-            <NotFoundPage />
-          </Suspense>
-        ),
       },
     ],
   },

--- a/app/src/@core/components/Modal/ReLoginDialog.tsx
+++ b/app/src/@core/components/Modal/ReLoginDialog.tsx
@@ -1,11 +1,14 @@
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { reLoginDialogInfoAtom } from '@core/atoms/reLoginDialogInfoAtom';
+import { ROUTES } from '@shared/constants/routes';
 import { AlertDialog } from '@shared/ui-kit';
 import { clearStorage } from '@shared/utils/storage/clearStorage';
 
 export const ReLoginDialog = () => {
+  const navigate = useNavigate();
   const [{ isOpen, description }, setReLoginDialogInfo] = useAtom(
     reLoginDialogInfoAtom,
   );
@@ -20,7 +23,7 @@ export const ReLoginDialog = () => {
   const handleConfirm = () => {
     clearStorage();
     closeReLoginDialog();
-    window.location.reload();
+    navigate(ROUTES.ROOT);
   };
 
   useEffect(() => {

--- a/app/src/@core/components/Spotlight/SpotlightListItem.tsx
+++ b/app/src/@core/components/Spotlight/SpotlightListItem.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
+import { useSetAtom } from 'jotai';
 import { useContext, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
 import { SpotlightFocusContext } from '@core/contexts/SpotlightFocusContext';
 import { Body1Text, HStack, Spacer } from '@shared/ui-kit';
 import { isEnterKeyDown } from '@shared/utils/keyboard';
@@ -21,6 +23,7 @@ export const SpotlightListItem = ({
 }: SpotlightListItemProps) => {
   const navigate = useNavigate();
   const { currentFocus, setCurrentFocus } = useContext(SpotlightFocusContext);
+  const setIsSpotlightOpen = useSetAtom(isSpotlightOpenAtom);
   const isFocused = currentFocus === index;
 
   useEffect(() => {
@@ -40,7 +43,11 @@ export const SpotlightListItem = ({
   }, [currentFocus, isFocused, navigate, link]);
 
   return (
-    <Link to={link} style={{ width: '100%' }}>
+    <Link
+      to={link}
+      onClick={() => setIsSpotlightOpen(false)}
+      style={{ width: '100%' }}
+    >
       <Layout isFocused={isFocused} onMouseOver={() => setCurrentFocus(index)}>
         <HStack w="100%" align="start" spacing="2rem">
           {left}

--- a/app/src/@core/components/Spotlight/SpotlightListItem.tsx
+++ b/app/src/@core/components/Spotlight/SpotlightListItem.tsx
@@ -33,6 +33,7 @@ export const SpotlightListItem = ({
         if (!isFocused) {
           return;
         }
+        setIsSpotlightOpen(false);
         navigate(link);
       }
     };
@@ -40,7 +41,7 @@ export const SpotlightListItem = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [currentFocus, isFocused, navigate, link]);
+  }, [currentFocus, isFocused, navigate, link, setIsSpotlightOpen]);
 
   return (
     <Link

--- a/app/src/@core/providers/ModalProvider.tsx
+++ b/app/src/@core/providers/ModalProvider.tsx
@@ -1,4 +1,5 @@
 import { useAtomValue } from 'jotai';
+import { Outlet } from 'react-router-dom';
 
 import { calculatorDialogAtom } from '@core/atoms/calculatorDialogAtom';
 import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
@@ -6,9 +7,8 @@ import { reLoginDialogInfoAtom } from '@core/atoms/reLoginDialogInfoAtom';
 import { CalculatorDialog } from '@core/components/Modal/CalculatorDialog';
 import { ReLoginDialog } from '@core/components/Modal/ReLoginDialog';
 import { Spotlight } from '@core/components/Spotlight';
-import type { PropsWithReactElementChildren } from '@shared/types/PropsWithChildren';
 
-const ModalProvider = ({ children }: PropsWithReactElementChildren) => {
+export const ModalProvider = () => {
   const { isOpen: isReLoginDialogOpen } = useAtomValue(reLoginDialogInfoAtom);
   const { isOpen: isCalculatorDialogOpen } = useAtomValue(calculatorDialogAtom);
   const isSpotlightOpen = useAtomValue(isSpotlightOpenAtom);
@@ -18,9 +18,7 @@ const ModalProvider = ({ children }: PropsWithReactElementChildren) => {
       {isReLoginDialogOpen ? <ReLoginDialog /> : null}
       {isSpotlightOpen ? <Spotlight /> : null}
       {isCalculatorDialogOpen ? <CalculatorDialog /> : null}
-      {children}
+      <Outlet />
     </>
   );
 };
-
-export default ModalProvider;


### PR DESCRIPTION
## Summary

그냥 ModalProvider를 router 안으로 옮겼습니다. 

- appRouter.tsx 의 변경사항이 복잡하게 잡혔는데, 그냥 제일 바깥에 ModalProvider로 감싼 것 밖에 변경한게 없으니 참고 바랍니다. 

## Describe your changes

기존 Spotlight에서 location 변경을 useEffect로 감지하여 바뀌면 Spotlight가 닫히도록 했던 코드를, SpotlightListItem의 Link onClick 시 닫히도록 수정하였습니다. 다시 useEffect 코드를 살리려고 봤는데, 굳이 Spotlight 전체에 useEffect를 걸 필요가 없더라구요. 

## Issue number and link
- Ref. #346 
- Ref. #352 (해당 PR에서 했던 일을 되돌리고 다른 방식으로 해결한 것이라 보시면 됩니다)