### PR TITLE
[Fix] (CalculatorDialog) description이 고정되어 있음

### DIFF
--- a/app/src/@core/atoms/calculatorDialogAtom.ts
+++ b/app/src/@core/atoms/calculatorDialogAtom.ts
@@ -2,5 +2,6 @@ import { atom } from 'jotai';
 
 export const calculatorDialogAtom = atom({
   isOpen: false,
+  description: '',
   focus: -1,
 });

--- a/app/src/@core/components/Modal/CalculatorDialog.tsx
+++ b/app/src/@core/components/Modal/CalculatorDialog.tsx
@@ -7,7 +7,8 @@ import { AlertDialog } from '@shared/ui-kit';
 import { isEnterKeyDown, isEscapeKeyDown } from '@shared/utils/keyboard';
 
 export const CalculatorDialog = () => {
-  const [{ focus }, setIsModalOpen] = useAtom(calculatorDialogAtom);
+  const [{ focus, description }, setIsModalOpen] =
+    useAtom(calculatorDialogAtom);
   const setCurrentOpenSpotlightIndex = useSetAtom(
     currentOpenSpotlightIndexAtom,
   );
@@ -15,6 +16,7 @@ export const CalculatorDialog = () => {
   const handleConfirm = () => {
     setIsModalOpen({
       isOpen: false,
+      description: '',
       focus: -1,
     });
     setCurrentOpenSpotlightIndex(focus);
@@ -38,11 +40,9 @@ export const CalculatorDialog = () => {
   return (
     <AlertDialog
       isOpen
-      onClose={() => {
-        /* can't close */
-      }}
+      onClose={handleConfirm}
       title="프로젝트 추가 오류"
-      description="이미 추가된 프로젝트입니다."
+      description={description}
       confirmText="확인"
       onConfirm={handleConfirm}
     />

--- a/app/src/Calculator/components/ProjectSpotlight/Spotlight.tsx
+++ b/app/src/Calculator/components/ProjectSpotlight/Spotlight.tsx
@@ -46,6 +46,7 @@ export const Spotlight = ({
     if (checkDuplicateSubject(subjectList, name, index)) {
       setCalculatorDialog({
         isOpen: true,
+        description: '이미 추가된 프로젝트입니다.',
         focus: currentOpenSpotlightIndex,
       });
       setCurrentOpenSpotlightIndex(-1);


### PR DESCRIPTION
## Summary

- 이전에 올리셨던 커밋에 빌드 에러가 있길래 확인해보다가 발견하였습니다. 
- **프로젝트 추가 오류**에는 20개 이상의 프로젝트를 추가했을 때, 동일한 프로젝트를 추가했을 때로 description이 두 가지가 나올 수 있는데 기존 올리신 코드에서는 고정되어있어 고쳤습니다. 

## Describe your changes

@42sungwook 커밋 올리시기 전에 `pnpm build:dev` 해서 빌드 에러가 없는지 확인 후 올려주시기 바랍니다. 

## Issue number and link
