### PR TITLE
[Design] Mobile Spotlight Trigger를 헤더로 올림

### DIFF
--- a/app/src/@core/components/Header/Mobile/index.tsx
+++ b/app/src/@core/components/Header/Mobile/index.tsx
@@ -2,17 +2,20 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
 import { MobileNavBarButton } from '@core/components/NavBar/Mobile/MobileNavBarButton';
+import { SearchButtonTriggerSpotlight } from '@core/components/Spotlight/SearchButtonTriggerSpotlight';
 import { AppLogoTitle } from '@shared/components/AppLogoTitle';
 import { ROUTES } from '@shared/constants/routes';
-import { HStack } from '@shared/ui-kit';
+import { HStack, Spacer } from '@shared/ui-kit';
 
 export const MobileHeader = () => {
   return (
     <Layout>
-      <HStack w="100%" h="6rem" justify="space-between">
+      <HStack w="100%" h="6rem" spacing="2rem">
         <Link to={ROUTES.ROOT}>
           <AppLogoTitle size="sm" />
         </Link>
+        <Spacer />
+        <SearchButtonTriggerSpotlight />
         <MobileNavBarButton />
       </HStack>
     </Layout>

--- a/app/src/@core/components/NavBar/Tablet/index.tsx
+++ b/app/src/@core/components/NavBar/Tablet/index.tsx
@@ -1,24 +1,15 @@
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 
-import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
 import { TabletNavDrawer } from '@core/components/NavBar/Tablet/TabletNavDrawer';
 import { TabletNavMenu } from '@core/components/NavBar/Tablet/TabletNavMenu';
 import { TabletNavProfile } from '@core/components/NavProfile/Tablet';
-import { ReactComponent as MdSearch } from '@shared/assets/icon/md-search.svg';
+import { SearchButtonTriggerSpotlight } from '@core/components/Spotlight/SearchButtonTriggerSpotlight';
 import { userAtom } from '@shared/atoms/userAtom';
-import { ARIA_LABEL } from '@shared/constants/accessibility';
-import { Center, Clickable, VStack } from '@shared/ui-kit';
+import { Center, VStack } from '@shared/ui-kit';
 
 export const TabletNavBar = () => {
-  const theme = useTheme();
   const user = useAtomValue(userAtom);
-  const setIsSpotlightOpen = useSetAtom(isSpotlightOpenAtom);
-
-  const openSpotlight = () => {
-    setIsSpotlightOpen(true);
-  };
 
   return (
     <Layout>
@@ -27,12 +18,7 @@ export const TabletNavBar = () => {
         <Center h="12rem">
           <TabletNavProfile imgUrl={user.imgUrl} />
         </Center>
-        <Clickable
-          onClick={openSpotlight}
-          aria-label={ARIA_LABEL.BUTTON.SEARCH_USER_OR_PROJECT_USING_SPOTLIGHT}
-        >
-          <MdSearch width={20} height={20} fill={theme.colors.mono.black} />
-        </Clickable>
+        <SearchButtonTriggerSpotlight />
         <TabletNavMenu />
       </VStack>
     </Layout>

--- a/app/src/@core/components/SearchBarShapeButton/index.tsx
+++ b/app/src/@core/components/SearchBarShapeButton/index.tsx
@@ -14,13 +14,9 @@ export const SearchBarShapeButton = () => {
   const browser = detect();
   const isMacOS = browser?.os === 'Mac OS';
 
-  const openSpotlight = () => {
-    setIsSpotlightOpen(true);
-  };
-
   return (
     <Layout
-      onClick={openSpotlight}
+      onClick={() => setIsSpotlightOpen(true)}
       aria-label={ARIA_LABEL.BUTTON.SEARCH_USER_OR_PROJECT_USING_SPOTLIGHT}
     >
       <HStack w="100%" spacing="1.6rem">

--- a/app/src/@core/components/Spotlight/SearchButtonTriggerSpotlight.tsx
+++ b/app/src/@core/components/Spotlight/SearchButtonTriggerSpotlight.tsx
@@ -1,0 +1,21 @@
+import { useTheme } from '@emotion/react';
+import { useSetAtom } from 'jotai';
+
+import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
+import { ReactComponent as MdSearch } from '@shared/assets/icon/md-search.svg';
+import { ARIA_LABEL } from '@shared/constants/accessibility';
+import { Clickable } from '@shared/ui-kit';
+
+export const SearchButtonTriggerSpotlight = () => {
+  const theme = useTheme();
+  const setIsSpotlightOpen = useSetAtom(isSpotlightOpenAtom);
+
+  return (
+    <Clickable
+      onClick={() => setIsSpotlightOpen(true)}
+      aria-label={ARIA_LABEL.BUTTON.SEARCH_USER_OR_PROJECT_USING_SPOTLIGHT}
+    >
+      <MdSearch width={20} height={20} fill={theme.colors.mono.black} />
+    </Clickable>
+  );
+};

--- a/app/src/@core/layouts/MainLayout/index.tsx
+++ b/app/src/@core/layouts/MainLayout/index.tsx
@@ -9,7 +9,6 @@ import { isSpotlightOpenAtom } from '@core/atoms/isSpotlightOpenAtom';
 import { MobileHeader } from '@core/components/Header/Mobile';
 import { DesktopNavBar } from '@core/components/NavBar/Desktop';
 import { TabletNavBar } from '@core/components/NavBar/Tablet';
-import { SearchBarShapeButton } from '@core/components/SearchBarShapeButton';
 import { mainLayoutGlobalStyle } from '@core/layouts/MainLayout/mainLayoutGlobalStyle';
 import { Global, useTheme } from '@emotion/react';
 import { mq } from '@shared/utils/facepaint/mq';
@@ -52,9 +51,7 @@ const MainLayout = () => {
           {device === 'mobile' && (
             <>
               <MobileHeader />
-              <StyledSearchBarShapeButton>
-                <SearchBarShapeButton />
-              </StyledSearchBarShapeButton>
+              <div style={{ height: '10rem' }} />
             </>
           )}
           <Outlet />
@@ -69,12 +66,6 @@ const MarginLayer = styled.div`
     marginLeft: ['0', '7rem', '24rem'],
     paddingBottom: ['8rem', '0', '0'],
   })}
-`;
-
-const StyledSearchBarShapeButton = styled.div`
-  margin-top: 6rem; // fixed header height
-  width: 280px;
-  padding: 2rem 0;
 `;
 
 const Layout = styled.main`


### PR DESCRIPTION
## Summary

기존
<img width="499" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/cd445eb1-868a-4f77-b529-18180efd9ef0">

수정
<img width="501" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/56662987-b49d-4857-90b7-9a715a60f257">

## Describe your changes

검색 버튼이 혼자 붕 떠서 위로 깔끔하게 옮겼습니다.

## Issue number and link
