### PR TITLE
[Fix] background.main.default gradient 삭제

### DIFF
--- a/app/src/@core/layouts/MainLayout/mainLayoutGlobalStyle.tsx
+++ b/app/src/@core/layouts/MainLayout/mainLayoutGlobalStyle.tsx
@@ -1,15 +1,7 @@
 import { Theme, css } from '@emotion/react';
 
 export const mainLayoutGlobalStyle = (theme: Theme) => css`
-  html {
-    background-color: ${theme.colors.mono.white};
-    background: ${theme.colors.background.main.default};
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-  }
   body {
-    background: ${theme.colors.background.main.default};
-    background-repeat: no-repeat;
-    background-attachment: fixed;
+    background-color: ${theme.colors.background.main.default};
   }
 `;

--- a/app/src/@core/styles/darkTheme.tsx
+++ b/app/src/@core/styles/darkTheme.tsx
@@ -38,7 +38,7 @@ const colors = {
       theme: '#070f21',
     },
     main: {
-      default: 'linear-gradient(150deg, #262626 0%, #0a0a0a 100%)',
+      default: '#151515',
       theme: '#151515',
     },
     box: {

--- a/app/src/@core/styles/lightTheme.tsx
+++ b/app/src/@core/styles/lightTheme.tsx
@@ -38,8 +38,8 @@ const colors = {
       theme: '#070f21',
     },
     main: {
-      default: 'linear-gradient(150deg, #ffffff 0%, #e7e7e9 100%)',
-      theme: '#f2f2f2',
+      default: '#f4f4f4',
+      theme: '#f4f4f4',
     },
     box: {
       default: '#ffffff',


### PR DESCRIPTION
## Summary

## Describe your changes

- 문제의 원인은 `background-attachment: fixed`와 `background: linear-gradient()`를 동시에 사용한 것이었습니다. 
- 디자인 상 그라디언트 배경이 예쁘긴 하지만, 일단 단일 색으로 수정하였습니다. 

## Issue number and link
- close #359