### PR TITLE
[Fix] 기본 배율 지정, 과도한 확대/축소 제한

### DIFF
--- a/app/src/@shared/components/Chart/hooks/useDefaultOptions.ts
+++ b/app/src/@shared/components/Chart/hooks/useDefaultOptions.ts
@@ -29,12 +29,13 @@ const defaultOptions: ApexCharts.ApexOptions = {
       tools: {
         download: false,
         selection: false,
-        zoom: true,
         zoomin: true,
         zoomout: true,
-        pan: false,
+        zoom: true,
+        pan: true,
         reset: true,
       },
+      autoSelected: 'zoom',
     },
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif",

--- a/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { subMonths } from 'date-fns';
 
 import { gql } from '@shared/__generated__';
 import { LineChart } from '@shared/components/Chart';
@@ -8,7 +9,10 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { CALENDAR_MONTHS_FROM_FT_BEGIN_AT } from '@shared/constants/date';
+import {
+  CALENDAR_MONTHS_FROM_FT_BEGIN_AT,
+  MILLISECONDS,
+} from '@shared/constants/date';
 import { kiloFormatter } from '@shared/utils/formatters/kiloFormatter';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { injectEmptyMonth } from '@shared/utils/injectEmptyMonth';
@@ -94,6 +98,28 @@ const ScoreRecordsPerCoalitionChart = ({
   const options: ApexCharts.ApexOptions = {
     chart: {
       width: '100%',
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.MONTH * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
     },
     xaxis: {
       type: 'datetime',
@@ -101,11 +127,10 @@ const ScoreRecordsPerCoalitionChart = ({
         datetimeUTC: false,
         format: "'yy MMM",
       },
+      min: subMonths(new Date(), 8).getTime(),
     },
     colors: colors,
     yaxis: {
-      min: Math.floor(min / 10000) * 10000,
-      max: Math.ceil(max / 10000) * 10000,
       labels: {
         formatter: (value) => kiloFormatter(value, 0),
       },

--- a/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
+++ b/app/src/Home/dashboard-contents/Coalition/ScoreRecordsPerCoalition.tsx
@@ -119,6 +119,14 @@ const ScoreRecordsPerCoalitionChart = ({
             },
           };
         },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: subMonths(new Date(), 8).getTime(),
+              max: ctx.maxX,
+            },
+          };
+        },
       },
     },
     xaxis: {

--- a/app/src/Home/dashboard-contents/Eval/EvalCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/Eval/EvalCountRecords.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { subDays } from 'date-fns';
 
 import { gql } from '@shared/__generated__';
 import { AreaChart } from '@shared/components/Chart';
@@ -8,6 +9,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { MILLISECONDS } from '@shared/constants/date';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { injectEmptyDay } from '@shared/utils/injectEmptyDay';
 
@@ -24,7 +26,7 @@ const GET_EVAL_COUNT_RECORDS = gql(/* GraphQL */ `
 
 export const EvalCountRecords = () => {
   const title = '일간 평가 횟수 추이';
-  const last = 180;
+  const last = 365;
 
   const { loading, error, data } = useQuery(GET_EVAL_COUNT_RECORDS, {
     variables: {
@@ -69,12 +71,37 @@ type EvalCountRecordsChartProps = {
 
 const EvalCountRecordsChart = ({ series }: EvalCountRecordsChartProps) => {
   const options: ApexCharts.ApexOptions = {
+    chart: {
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.DAY * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
+    },
     xaxis: {
       type: 'datetime',
       labels: {
         format: 'MMM d',
         datetimeUTC: false,
       },
+      min: subDays(new Date(), 18).getTime(),
     },
     tooltip: {
       x: {

--- a/app/src/Home/dashboard-contents/Eval/EvalCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/Eval/EvalCountRecords.tsx
@@ -93,6 +93,14 @@ const EvalCountRecordsChart = ({ series }: EvalCountRecordsChartProps) => {
             },
           };
         },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: subDays(new Date(), 18).getTime(),
+              max: ctx.maxX,
+            },
+          };
+        },
       },
     },
     xaxis: {

--- a/app/src/Home/dashboard-contents/Team/TeamCloseRecords.tsx
+++ b/app/src/Home/dashboard-contents/Team/TeamCloseRecords.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { subDays } from 'date-fns';
 
 import { gql } from '@shared/__generated__';
 import { AreaChart } from '@shared/components/Chart';
@@ -8,6 +9,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { MILLISECONDS } from '@shared/constants/date';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { injectEmptyDay } from '@shared/utils/injectEmptyDay';
 
@@ -24,7 +26,7 @@ const GET_TEAM_CLOSE_RECORDS = gql(/* GraphQL */ `
 
 export const TeamCloseRecords = () => {
   const title = '일간 팀 제출 횟수 추이';
-  const last = 180;
+  const last = 365;
 
   const { loading, error, data } = useQuery(GET_TEAM_CLOSE_RECORDS, {
     variables: {
@@ -69,12 +71,37 @@ type EvalCountRecordsChartProps = {
 
 const EvalCountRecordsChart = ({ series }: EvalCountRecordsChartProps) => {
   const options: ApexCharts.ApexOptions = {
+    chart: {
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.DAY * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
+    },
     xaxis: {
       type: 'datetime',
       labels: {
         format: 'MMM d',
         datetimeUTC: false,
       },
+      min: subDays(new Date(), 18).getTime(),
     },
     tooltip: {
       x: {

--- a/app/src/Home/dashboard-contents/Team/TeamCloseRecords.tsx
+++ b/app/src/Home/dashboard-contents/Team/TeamCloseRecords.tsx
@@ -93,6 +93,14 @@ const EvalCountRecordsChart = ({ series }: EvalCountRecordsChartProps) => {
             },
           };
         },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: subDays(new Date(), 18).getTime(),
+              max: ctx.maxX,
+            },
+          };
+        },
       },
     },
     xaxis: {

--- a/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { subDays } from 'date-fns';
 
 import { gql } from '@shared/__generated__';
 import { AreaChart } from '@shared/components/Chart';
@@ -10,6 +11,7 @@ import {
 } from '@shared/components/DashboardContentView/Error';
 import { InfoTooltip } from '@shared/components/InfoTooltip';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
+import { MILLISECONDS } from '@shared/constants/date';
 
 const GET_DAILY_ALIVE_USER_COUNT_RECORDS = gql(/* GraphQL */ `
   query GetDailyAliveUserCountRecords($last: Int!) {
@@ -78,12 +80,37 @@ const ActiveUserCountRecordsChart = ({
   series,
 }: ActiveUserCountRecordsChartProps) => {
   const options: ApexCharts.ApexOptions = {
+    chart: {
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.DAY * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
+    },
     xaxis: {
       type: 'datetime',
       labels: {
         format: "'yy MMM",
         datetimeUTC: false,
       },
+      min: subDays(new Date(), 18).getTime(),
     },
     yaxis: {
       labels: {

--- a/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/User/AliveUserCountRecords.tsx
@@ -10,8 +10,8 @@ import {
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
 import { InfoTooltip } from '@shared/components/InfoTooltip';
-import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { MILLISECONDS } from '@shared/constants/date';
+import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 
 const GET_DAILY_ALIVE_USER_COUNT_RECORDS = gql(/* GraphQL */ `
   query GetDailyAliveUserCountRecords($last: Int!) {
@@ -99,6 +99,14 @@ const ActiveUserCountRecordsChart = ({
             xaxis: {
               min: newMinX,
               max: newMaxX,
+            },
+          };
+        },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: subDays(new Date(), 18).getTime(),
+              max: ctx.maxX,
             },
           };
         },

--- a/app/src/Home/dashboard-contents/User/BlackholedCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedCountRecords.tsx
@@ -100,6 +100,14 @@ const BlackholedCountRecordsChart = ({
             },
           };
         },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: subMonths(new Date(), 12).getTime(),
+              max: ctx.maxX,
+            },
+          };
+        },
       },
     },
     xaxis: {

--- a/app/src/Home/dashboard-contents/User/BlackholedCountRecords.tsx
+++ b/app/src/Home/dashboard-contents/User/BlackholedCountRecords.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { subMonths } from 'date-fns';
 
 import { gql } from '@shared/__generated__';
 import { AreaChart } from '@shared/components/Chart';
@@ -8,7 +9,10 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
-import { CALENDAR_MONTHS_FROM_FT_BEGIN_AT } from '@shared/constants/date';
+import {
+  CALENDAR_MONTHS_FROM_FT_BEGIN_AT,
+  MILLISECONDS,
+} from '@shared/constants/date';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { injectEmptyMonth } from '@shared/utils/injectEmptyMonth';
 
@@ -74,13 +78,37 @@ const BlackholedCountRecordsChart = ({
   series,
 }: BlackholedCountRecordsChartProps) => {
   const options: ApexCharts.ApexOptions = {
+    chart: {
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.MONTH * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
+    },
     xaxis: {
       type: 'datetime',
-
       labels: {
         datetimeUTC: false,
         format: "'yy MMM",
       },
+      min: subMonths(new Date(), 12).getTime(),
     },
     tooltip: {
       x: {

--- a/app/src/Profile/dashboard-contents/Eval/CountRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/CountRecords.tsx
@@ -103,6 +103,17 @@ const CountRecordsChart = ({ series }: CountRecordsChartProps) => {
             },
           };
         },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: Math.max(
+                beginAt.getTime(),
+                subMonths(new Date(), 12).getTime(),
+              ),
+              max: ctx.maxX,
+            },
+          };
+        },
       },
     },
     xaxis: {

--- a/app/src/Profile/dashboard-contents/Eval/CountRecords.tsx
+++ b/app/src/Profile/dashboard-contents/Eval/CountRecords.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client';
-import { differenceInCalendarMonths } from 'date-fns';
+import { differenceInCalendarMonths, subMonths } from 'date-fns';
 import { useContext } from 'react';
 
 import { BeginAtContext } from '@/Profile/contexts/BeginAtContext';
@@ -12,6 +12,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { MILLISECONDS } from '@shared/constants/date';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { injectEmptyMonth } from '@shared/utils/injectEmptyMonth';
 
@@ -77,14 +78,40 @@ type CountRecordsChartProps = {
 };
 
 const CountRecordsChart = ({ series }: CountRecordsChartProps) => {
+  const beginAt = useContext(BeginAtContext);
+
   const options: ApexCharts.ApexOptions = {
+    chart: {
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.MONTH * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
+    },
     xaxis: {
       type: 'datetime',
-
       labels: {
         datetimeUTC: false,
         format: "'yy MMM",
       },
+      min: Math.max(beginAt.getTime(), subMonths(new Date(), 12).getTime()),
     },
     tooltip: {
       x: {

--- a/app/src/Profile/dashboard-contents/LogtimeAndProject/LogtimeRecords.tsx
+++ b/app/src/Profile/dashboard-contents/LogtimeAndProject/LogtimeRecords.tsx
@@ -102,6 +102,17 @@ const LogtimeRecordsChart = ({ series }: LogtimeRecordsChartProps) => {
             },
           };
         },
+        beforeResetZoom: (ctx) => {
+          return {
+            xaxis: {
+              min: Math.max(
+                beginAt.getTime(),
+                subMonths(new Date(), 12).getTime(),
+              ),
+              max: ctx.maxX,
+            },
+          };
+        },
       },
     },
     xaxis: {

--- a/app/src/Profile/dashboard-contents/LogtimeAndProject/LogtimeRecords.tsx
+++ b/app/src/Profile/dashboard-contents/LogtimeAndProject/LogtimeRecords.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client';
-import { differenceInCalendarMonths } from 'date-fns';
+import { differenceInCalendarMonths, subMonths } from 'date-fns';
 import { useContext } from 'react';
 
 import { BeginAtContext } from '@/Profile/contexts/BeginAtContext';
@@ -12,6 +12,7 @@ import {
   DashboardContentLoading,
   DashboardContentNotFound,
 } from '@shared/components/DashboardContentView/Error';
+import { MILLISECONDS } from '@shared/constants/date';
 import { numberWithUnitFormatter } from '@shared/utils/formatters/numberWithUnitFormatter';
 import { injectEmptyMonth } from '@shared/utils/injectEmptyMonth';
 
@@ -76,7 +77,33 @@ type LogtimeRecordsChartProps = {
 };
 
 const LogtimeRecordsChart = ({ series }: LogtimeRecordsChartProps) => {
+  const beginAt = useContext(BeginAtContext);
+
   const options: ApexCharts.ApexOptions = {
+    chart: {
+      events: {
+        beforeZoom: (ctx, { xaxis }) => {
+          if (xaxis.max - xaxis.min < MILLISECONDS.MONTH * 2) {
+            return {
+              xaxis: {
+                min: ctx.minX,
+                max: ctx.maxX,
+              },
+            };
+          }
+
+          const newMinX = Math.max(xaxis.min, ctx.w.globals.initialMinX);
+          const newMaxX = Math.min(xaxis.max, ctx.w.globals.initialMaxX);
+
+          return {
+            xaxis: {
+              min: newMinX,
+              max: newMaxX,
+            },
+          };
+        },
+      },
+    },
     xaxis: {
       type: 'datetime',
 
@@ -84,6 +111,7 @@ const LogtimeRecordsChart = ({ series }: LogtimeRecordsChartProps) => {
         datetimeUTC: false,
         format: "'yy MMM",
       },
+      min: Math.max(beginAt.getTime(), subMonths(new Date(), 12).getTime()),
     },
     yaxis: {
       labels: {


### PR DESCRIPTION
## Summary

차트 zoom-inout을 되살렸지만(#364), 무한정 확대/축소가 되어 UX에 좋지 않은 문제가 있었습니다. 

## Describe your changes

- 일간 지표 : 365일 불러옴, 최근 18일만 초기 표시, 축소 한계는 diff 2일, 확대 한계는 diff가 xrange 안일 때까지만 가능합니다. 
- 월간 지표 : 전체 지표의 경우 42 시작달, 유저의 경우 본과정 시작달로부터의 정보 불러옴, 최근 12개월만 초기 표시, 축소 한계는 diff 2개월, 확대 한계는 diff가 xrange 안일 때까지만 가능합니다. 
- pan 기능을 추가로 되살렸는데, 이건 차트 배율을 조정하지 않고 옆으로 슬라이드할 때 쓰는 겁니다. (하단 영상 참고)

## Issue number and link
- Ref: [Apex Charts- Limiting Zoom out](https://stackoverflow.com/questions/62815241/apex-charts-limiting-zoom-out)