### PR TITLE
[Hotfix] YearSelect width 줄이기

### DIFF
--- a/app/src/@shared/ui-kit/Select/SelectTrigger.tsx
+++ b/app/src/@shared/ui-kit/Select/SelectTrigger.tsx
@@ -18,7 +18,7 @@ type SelectTriggerProps = {
 export const SelectTrigger = ({
   left,
   right,
-  spacing = '1.5rem',
+  spacing = '0.5rem',
   placeholder = '',
 }: SelectTriggerProps) => {
   const theme = useTheme();

--- a/app/src/Profile/dashboard-contents/General/DailyActivities/YearSelect/index.tsx
+++ b/app/src/Profile/dashboard-contents/General/DailyActivities/YearSelect/index.tsx
@@ -19,7 +19,7 @@ export const YearSelect = ({ list, onChange }: YearSelectProps) => {
   };
 
   return (
-    <Select width="14rem" onValueChange={handleChange}>
+    <Select width="12rem" onValueChange={handleChange}>
       <SelectTrigger placeholder="최근 1년" />
       <SelectContent>
         <SelectItem value={null}>


### PR DESCRIPTION
> **main** 브랜치로 향하는 PR입니다.

## Summary

360px에 가까운 디바이스에서 잔디 카드의 총점이 4자리 수인 유저의 잔디 카드를 보는 경우 Overflow가 발생하는 것을 확인하였습니다. 

## Describe your changes

YearSelect(대상 연도를 고르는 Select) 크기를 축소시켰습니다. 

![image](https://github.com/42Statistics/42Stat-Frontend/assets/61629480/c2d79091-112b-46c7-9976-44648bbe13fc)

## Issue number and link
