### PR TITLE
[Hotfix] 말일 setMonth 관련 오동작 (to develop)

### DIFF
--- a/app/src/@shared/utils/firstDayInPreviousMonth.ts
+++ b/app/src/@shared/utils/firstDayInPreviousMonth.ts
@@ -1,0 +1,3 @@
+export const firstDayInPreviousMonth = (date: Date, month: number) => {
+  return new Date(date.getFullYear(), date.getMonth() - month, 1);
+};

--- a/app/src/@shared/utils/injectEmptyMonth.ts
+++ b/app/src/@shared/utils/injectEmptyMonth.ts
@@ -1,5 +1,7 @@
 import { isSameMonth, isSameYear } from 'date-fns';
 
+import { firstDayInPreviousMonth } from './firstDayInPreviousMonth';
+
 export const injectEmptyMonth = (
   series: { x: Date; y: number }[],
   last: number,
@@ -9,8 +11,7 @@ export const injectEmptyMonth = (
   let currIndex = 0;
 
   for (let i = last - 1; i >= 0; i--) {
-    const date = new Date();
-    date.setMonth(date.getMonth() - i);
+    const date = firstDayInPreviousMonth(new Date(), i);
 
     if (
       currIndex < series.length &&


### PR DESCRIPTION
## Summary

setMonth 관련 미처 생각하지 못했던 오동작이 있어 수정하였습니다. 

현재 날짜(2023.12.30)가 28일 초과라 발생하는 문제입니다. 

<img width="352" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/87dd615a-b3e4-43da-b1e3-0fc203bf9f05">

## Describe your changes

- 3월 31일의 한 달 전은 2월 28일이 아니라 Date(2023, 2-1, 31), 2월 31일, 즉 3월 3일로 계산됩니다.
- 3월 1일의 한 달 전은 Date(2023, 2-1, 31), 2월 1일로 잘 계산됩니다. 

월간 지표이지만 일이 중요한 경우 (ex. 여행 중인 유저 수 추이 같은 지표가 말일이 기준이 되는 경우)가 추후에 생길 수도 있을 것 같아 굳이 1일로 날짜를 조정하지 않았었는데, setMonth를 할 때 오동작이 발생할 수 있다는 것을 간과하였습니다. 

<img width="342" alt="image" src="https://github.com/42Statistics/42Stat-Frontend/assets/61629480/aeeeef65-aa33-48a6-af46-9c0ef93859f3">


## Issue number and link
