### PR TITLE
[Fix] 잔디 무한로딩 버그

### DIFF
--- a/app/src/Profile/dashboard-contents/General/DailyActivities/index.tsx
+++ b/app/src/Profile/dashboard-contents/General/DailyActivities/index.tsx
@@ -15,6 +15,7 @@ import { DailyActivitiesResult } from '@/Profile/dashboard-contents/General/Dail
 import { DailyActivityTitleDescriptor } from '@/Profile/dashboard-contents/General/DailyActivities/DailyActivityTitleDescriptor';
 import { YearSelect } from '@/Profile/dashboard-contents/General/DailyActivities/YearSelect';
 import { calculateDailyActivityScores } from '@/Profile/dashboard-contents/General/DailyActivities/utils/calculateDailyActivityScores';
+import { dailyActivityErrorAtom } from '@/Profile/dashboard-contents/General/atoms/dailyActivityErrorAtom';
 import { dailyActivitySumAtom } from '@/Profile/dashboard-contents/General/atoms/dailyActivitySumAtom';
 import { selectedDailyActivityAtom } from '@/Profile/dashboard-contents/General/atoms/selectedDailyActivityAtom';
 
@@ -47,8 +48,9 @@ export const DailyActivities = () => {
   const result = useQuery(GET_DAILY_ACTIVITIES_BY_LOGIN, {
     variables: { login, year: year ?? undefined },
   });
-  const { data, refetch } = result;
+  const { data, error, refetch } = result;
   const beginAt = useContext(BeginAtContext);
+  const setDailyActivityError = useSetAtom(dailyActivityErrorAtom);
 
   const { dailyActivities } = data?.getPersonalGeneral ?? {};
   const dailyActivityScores =
@@ -65,6 +67,7 @@ export const DailyActivities = () => {
 
   const setDailyActivitySum = useSetAtom(dailyActivitySumAtom);
   const setSelectedDailyActivity = useSetAtom(selectedDailyActivityAtom);
+  setDailyActivityError(error);
 
   useEffect(() => {
     if (dailyActivities === undefined) {

--- a/app/src/Profile/dashboard-contents/General/DailyActivityDetail/index.tsx
+++ b/app/src/Profile/dashboard-contents/General/DailyActivityDetail/index.tsx
@@ -5,10 +5,14 @@ import dayjs from 'dayjs';
 import { useAtomValue } from 'jotai';
 
 import { DashboardContent } from '@shared/components/DashboardContent';
-import { DashboardContentLoading } from '@shared/components/DashboardContentView/Error';
+import {
+  DashboardContentBadRequest,
+  DashboardContentLoading,
+} from '@shared/components/DashboardContentView/Error';
 import { Body1Text, VStack } from '@shared/ui-kit';
 
 import { UserProfileContext } from '@/Profile/contexts/UserProfileContext';
+import { dailyActivityErrorAtom } from '@/Profile/dashboard-contents/General/atoms/dailyActivityErrorAtom';
 import { selectedDailyActivityAtom } from '@/Profile/dashboard-contents/General/atoms/selectedDailyActivityAtom';
 
 import { DailyActivityTimeline } from './DailyActivityTimeline';
@@ -19,6 +23,7 @@ export const DailyActivityDetail = () => {
   const theme = useTheme();
   const { login } = useContext(UserProfileContext);
   const { coalition } = useContext(UserProfileContext);
+  const dailyActivityError = useAtomValue(dailyActivityErrorAtom);
 
   const {
     date,
@@ -30,6 +35,15 @@ export const DailyActivityDetail = () => {
 
   const title = '일별 활동 내역';
   const description = dayjs(date).format('YYYY년 M월 D일');
+
+  if (dailyActivityError) {
+    return (
+      <DashboardContentBadRequest
+        title={title}
+        message={dailyActivityError.message}
+      />
+    );
+  }
 
   if (date === '' || activityLogin !== login) {
     return <DashboardContentLoading title={title} />;

--- a/app/src/Profile/dashboard-contents/General/atoms/dailyActivityErrorAtom.ts
+++ b/app/src/Profile/dashboard-contents/General/atoms/dailyActivityErrorAtom.ts
@@ -1,0 +1,4 @@
+import { ApolloError } from '@apollo/client';
+import { atom } from 'jotai';
+
+export const dailyActivityErrorAtom = atom<ApolloError | undefined>(undefined);


### PR DESCRIPTION
## Summary
이론상 잔디 무한로딩이 생길 수 있어 atom으로 에러상태를 추가했습니다
## Describe your changes
잔디카드(세부내용카드 X)에는 로딩상태가 없던데 의도된건지 모르겠어서 놔뒀습니다.
지금은 로딩, 에러 상태 둘 다 잔디는 비어있고(잔디 그리드는 남아있고 색깔만 비어있음)
세부내용카드에 로딩, 에러가 나게 구현되어있습니다

수정) 로딩 이슈로 남겨놓은걸 지금 봤네요. 따로 작업하시는걸로 알겠습니다!
## Issue number and link
- close #433 