### PR TITLE
[Hotfix] 계산기 input 버그

### DIFF
--- a/app/src/@shared/ui-kit/Writable/WritableNum.tsx
+++ b/app/src/@shared/ui-kit/Writable/WritableNum.tsx
@@ -7,16 +7,8 @@ export const WritableNum = forwardRef(
     props: React.InputHTMLAttributes<HTMLInputElement>,
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const { value, ...restProps } = props;
-
     return (
-      <StyledWritable
-        {...restProps}
-        value={value?.toString()}
-        type="number"
-        ref={ref}
-        autoComplete="off"
-      />
+      <StyledWritable {...props} type="number" ref={ref} autoComplete="off" />
     );
   },
 );

--- a/app/src/Calculator/components/CalculatorBasicInfoInputGroup/index.tsx
+++ b/app/src/Calculator/components/CalculatorBasicInfoInputGroup/index.tsx
@@ -14,6 +14,7 @@ import {
 
 import { calculatorUserInfoAtom } from '@/Calculator/atoms/calculatorUserInfoAtom';
 import { subjectListAtom } from '@/Calculator/atoms/subjectListAtom';
+import { MAX_LEVEL } from '@/Calculator/constants/levelRecords';
 import { useSubjectList } from '@/Calculator/hooks/useSubjectList';
 
 export const CalculatorBasicInfoInputGroup = () => {
@@ -24,13 +25,24 @@ export const CalculatorBasicInfoInputGroup = () => {
   const subjectList = useAtomValue(subjectListAtom);
   const { updateSubjectList } = useSubjectList();
 
+  const parseInputValue = (value: number) => {
+    const stringValue = value.toString();
+
+    if (stringValue === '0') return '';
+    return value;
+  };
+
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    const value = Number(e.target.value);
-    if (isNaN(value) || value < 0) return;
+    const { value, name: targetName } = e.target;
+    let numericValue = parseFloat(value);
+
+    if (isNaN(numericValue) || numericValue < 0) numericValue = 0;
+    if (targetName === 'currentLevel' && numericValue > MAX_LEVEL)
+      numericValue = MAX_LEVEL;
     const name = e.target.name as keyof typeof calculatorUserInfoAtom;
     setCalculatorUserInfo((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: numericValue,
     }));
   };
 
@@ -53,7 +65,7 @@ export const CalculatorBasicInfoInputGroup = () => {
             min="0"
             max="30"
             step="0.01"
-            value={currentLevel}
+            value={parseInputValue(currentLevel)}
             onChange={handleChange}
             style={{ width: '5rem' }}
           />
@@ -69,7 +81,7 @@ export const CalculatorBasicInfoInputGroup = () => {
             <WritableNum
               name="currentBlackhole"
               min="0"
-              value={currentBlackhole}
+              value={parseInputValue(currentBlackhole)}
               onChange={handleChange}
               style={{ width: '5rem' }}
             />
@@ -91,7 +103,7 @@ export const CalculatorBasicInfoInputGroup = () => {
             <WritableNum
               name="daysFromStart"
               min="0"
-              value={daysFromStart}
+              value={parseInputValue(daysFromStart)}
               onChange={handleChange}
               style={{ width: '5rem' }}
             />

--- a/app/src/Calculator/components/CalculatorBasicInfoInputGroup/index.tsx
+++ b/app/src/Calculator/components/CalculatorBasicInfoInputGroup/index.tsx
@@ -25,13 +25,6 @@ export const CalculatorBasicInfoInputGroup = () => {
   const subjectList = useAtomValue(subjectListAtom);
   const { updateSubjectList } = useSubjectList();
 
-  const parseInputValue = (value: number) => {
-    const stringValue = value.toString();
-
-    if (stringValue === '0') return '';
-    return value;
-  };
-
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     const { value, name: targetName } = e.target;
     let numericValue = parseFloat(value);
@@ -65,7 +58,7 @@ export const CalculatorBasicInfoInputGroup = () => {
             min="0"
             max="30"
             step="0.01"
-            value={parseInputValue(currentLevel)}
+            defaultValue={currentLevel === 0 ? '' : currentLevel}
             onChange={handleChange}
             style={{ width: '5rem' }}
           />
@@ -81,7 +74,7 @@ export const CalculatorBasicInfoInputGroup = () => {
             <WritableNum
               name="currentBlackhole"
               min="0"
-              value={parseInputValue(currentBlackhole)}
+              defaultValue={currentBlackhole === 0 ? '' : currentBlackhole}
               onChange={handleChange}
               style={{ width: '5rem' }}
             />
@@ -103,7 +96,7 @@ export const CalculatorBasicInfoInputGroup = () => {
             <WritableNum
               name="daysFromStart"
               min="0"
-              value={parseInputValue(daysFromStart)}
+              defaultValue={daysFromStart === 0 ? '' : daysFromStart}
               onChange={handleChange}
               style={{ width: '5rem' }}
             />

--- a/app/src/Calculator/constants/levelRecords.ts
+++ b/app/src/Calculator/constants/levelRecords.ts
@@ -1,2 +1,3 @@
 export const MAX_XAXIS_COUNT = 8;
 export const MAX_XVALUE_LENGTH = 20;
+export const MAX_LEVEL = 30;

--- a/app/src/Calculator/hooks/useSubjectList.ts
+++ b/app/src/Calculator/hooks/useSubjectList.ts
@@ -59,7 +59,6 @@ export const useSubjectList = () => {
             ) / 100;
 
           if (isNaN(newLevel)) {
-            console.log('isNaN returned');
             return 0;
           }
           return newLevel;

--- a/app/src/Calculator/hooks/useSubjectList.ts
+++ b/app/src/Calculator/hooks/useSubjectList.ts
@@ -47,6 +47,8 @@ export const useSubjectList = () => {
             (exp) => exp > newCurrentExp,
           );
 
+          if (newDecimalLevel === -1) return expMaxTable.length - 1;
+
           //레벨 소숫점 2자리까지 Math.round로 계산
           const newLevel =
             Math.round(
@@ -56,12 +58,20 @@ export const useSubjectList = () => {
                 100,
             ) / 100;
 
-          if (isNaN(newLevel)) return 0;
+          if (isNaN(newLevel)) {
+            console.log('isNaN returned');
+            return 0;
+          }
           return newLevel;
         };
 
         const calculateCurrentExp = (newStartLevel: number) => {
           const decimalLevel = Math.floor(newStartLevel);
+
+          //최대 레벨에 도달한 경우
+          if (decimalLevel >= expMaxTable.length - 1) {
+            return expMaxTable[expMaxTable.length - 1];
+          }
           const currentTotalExp = Math.floor(
             expMaxTable[decimalLevel] +
               expReqTable[decimalLevel + 1] * (newStartLevel - decimalLevel),


### PR DESCRIPTION
## Summary
계산기 input + 레벨 버그
#440 이슈 참고

## Describe your changes
썩 내키지는 않지만 레퍼런스를 찾아봐도 지금의 현상을 깔끔하게 고칠만한 로직을 찾지 못해 제가 생각하는 가장 깔끔한 방법으로 고쳤습니다
아래의 사항 고려

input 버그
1. input을 text로 고치면 깔끔하게 해결되지만 step을 사용하지 못함 -> 타입 number 유지
2. value가 0일 때 숫자를 입력하면 숫자 앞에 0이 유지되는 현상이 있음(0일 때 1을 입력하면 1이 아닌 01로 표기됨) -> value를 파싱하는 함수 추가해서 이제 값을 지우면 0이 아닌 빈 문자열로 표기
3. xx.0x 숫자를 입력할 때 소숫점 아래 0이 사라져서 숫자 입력을 못하는 현상 -> parseFloat 사용

레벨 버그
현재 레벨 테이블이 30까지 있어서 30보다 높아지면 30으로 유지되어야하는데 0으로 초기화되서 다시 계산되는 현상 확인
- max 상수값을 만들고 계산 hook에서 max 레벨이 유지되도록 변경

## Issue number and link
- close #440 